### PR TITLE
Add GitHub Pages deployment for demo app

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,39 @@
+name: Deploy Demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build:demo
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist-demo
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build && tsc -p tsconfig.build.json",
     "lint": "eslint .",
+    "build:demo": "vite build --config vite.config.demo.ts",
     "preview": "vite preview"
   },
   "peerDependencies": {

--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/react-leaflet-milsymbol/',
+  build: {
+    outDir: 'dist-demo',
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a `vite.config.demo.ts` that builds the demo app as a regular SPA (separate from the library build) with the correct base path for GitHub Pages
- Adds a `build:demo` npm script
- Adds a GitHub Actions workflow (`deploy-demo.yml`) that builds and deploys the demo on push to `main` or manual trigger

## Setup required
In the repo **Settings > Pages**, set the source to **GitHub Actions** (instead of "Deploy from a branch").

Once merged, the demo will be available at:
`https://jacorbello.github.io/react-leaflet-milsymbol/`