### PR TITLE
Fix CI: split into separate version bump and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,18 @@
-name: Build and Publish
+name: Publish to npm
 
 on:
   release:
     types: [created]
-  
-  workflow_dispatch:
-    inputs:
-      version_increment:
-        description: 'Version increment type'
-        required: false
-        type: choice
-        options:
-          - none
-          - patch
-          - minor
-          - major
-        default: 'none'
-      specific_version:
-        description: 'Specific version (overrides increment if provided, e.g. 1.2.3)'
-        required: false
-        type: string
 
 jobs:
-  build-and-publish:
+  publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -40,47 +20,14 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Configure Git
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
       - name: Install dependencies
         run: npm ci
-        
-      - name: Create version branch
-        if: ${{ github.event.inputs.specific_version != '' || github.event.inputs.version_increment != 'none' }}
-        run: |
-          BRANCH_NAME="version-update-$(date +'%Y%m%d%H%M%S')"
-          git checkout -b $BRANCH_NAME
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-      - name: Update version with specific version if provided
-        if: ${{ github.event.inputs.specific_version != '' }}
-        run: npm version ${{ github.event.inputs.specific_version }} -m "Bump version to %s [skip ci]"
-      
-      - name: Update version with increment if selected
-        if: ${{ github.event.inputs.specific_version == '' && github.event.inputs.version_increment != 'none' }}
-        run: npm version ${{ github.event.inputs.version_increment }} -m "Bump version to %s [skip ci]"
-        
       - name: Lint
         run: npm run lint
-        
+
       - name: Build
         run: npm run build
-
-      - name: Create Pull Request for version change
-        if: ${{ github.event.inputs.version_increment != 'none' || github.event.inputs.specific_version != '' }}
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update version [skip ci]"
-          title: "Version update"
-          body: |
-            Automated version update via GitHub Actions workflow
-          branch: ${{ env.BRANCH_NAME }}
-          base: main
-          delete-branch: true
 
       - name: Publish to npm
         run: npm publish

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,65 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_increment:
+        description: 'Version increment type'
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+      specific_version:
+        description: 'Specific version (overrides increment if provided, e.g. 1.2.3)'
+        required: false
+        type: string
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bump version
+        run: |
+          if [ -n "${{ github.event.inputs.specific_version }}" ]; then
+            npm version "${{ github.event.inputs.specific_version }}" --no-git-tag-version
+          else
+            npm version "${{ github.event.inputs.version_increment }}" --no-git-tag-version
+          fi
+          echo "NEW_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Bump version to ${{ env.NEW_VERSION }}"
+          title: "Bump version to ${{ env.NEW_VERSION }}"
+          body: |
+            Bumps package version to `${{ env.NEW_VERSION }}`.
+
+            Once merged, create a release to trigger publishing to npm.
+          branch: "version-bump/${{ env.NEW_VERSION }}"
+          base: main
+          delete-branch: true


### PR DESCRIPTION
## Summary

- **Fixes the failing "Create Pull Request for version change" step** — the old workflow conflicted with `peter-evans/create-pull-request` by manually creating a branch and committing via `npm version`, but the action expects to manage branches and detect uncommitted changes itself.
- Splits the single workflow into two: `version.yml` (version bump via `workflow_dispatch`) and `publish.yml` (npm publish on release creation).
- Version bump now uses `--no-git-tag-version` so changes stay uncommitted, letting `create-pull-request` handle branch/commit/PR properly.

## Intended release flow

1. Run "Version Bump" workflow from Actions tab (pick patch/minor/major or specific version)
2. Review and merge the auto-created PR
3. Create a GitHub Release targeting `main`
4. `publish.yml` triggers automatically and publishes to npm

## Test plan

- [ ] Trigger "Version Bump" workflow with a patch increment and verify PR is created
- [ ] Merge the version PR, create a release, and verify npm publish succeeds