### PR TITLE
Cleanup: dead effect, derived types, size precedence, stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pnpm add react-leaflet-milsymbol
 ```
 
 > [!IMPORTANT]
-> If using React 19, you will need to add the `--legacy-peer-deps` flag, as `react-leaflet` only supports React `^18.0.0`
+> If using React 19, install `react-leaflet` v5 — v4 supports React `^18.0.0` only.
 
 ### Dependencies
 
@@ -30,7 +30,7 @@ This package requires the following peer dependencies:
 - `react` (v18.0.0 or v19.0.0)
 - `react-dom` (v18.0.0 or v19.0.0)
 - `leaflet` (v1.9.0 or higher)
-- `react-leaflet` (v4.0.0 or higher)
+- `react-leaflet` (v4 or v5 — use v5 with React 19)
 - `milsymbol` (v3.0.0 or higher)
 
 Make sure to install these dependencies in your project if you haven't already.
@@ -47,6 +47,12 @@ The `sidc` prop accepts Symbol Identification Codes in both letter-based (APP-6B
 For more details on constructing SIDCs, see the [milsymbol documentation](https://www.spatialillusions.com/milsymbol/documentation.html).
 
 ## Usage
+
+> [!WARNING]
+> **Breaking change in 0.3.0** — the `size` prop now takes precedence over
+> `options.size`. If you passed both, the symbol previously rendered at
+> `options.size` and now renders at `size`. Passing only one of them is
+> unaffected.
 
 ### Basic Example (Letter-based SIDC)
 
@@ -94,7 +100,7 @@ The `MilSymbol` component accepts the following props:
 | ---------------- | ----------------------- | -------------------------------------------------------- |
 | `position`       | `[number, number]`      | Latitude and longitude where the symbol should be placed |
 | `sidc`           | `string`                | Symbol Identification Code (letter-based or numeric)     |
-| `size`           | `number`                | Size of the symbol (default: 35)                         |
+| `size`           | `number`                | Size of the symbol (default: 35). Takes precedence over `options.size` |
 | `options`        | `object`                | Additional options to customize the symbol (see below)   |
 | `tooltipContent` | `string` or `ReactNode` | Optional content for tooltip                             |
 | `popupContent`   | `string` or `ReactNode` | Optional content for popup                               |

--- a/src/__tests__/MilSymbol.test.tsx
+++ b/src/__tests__/MilSymbol.test.tsx
@@ -171,4 +171,40 @@ describe('MilSymbol', () => {
     render(<MilSymbol position={[0, 0]} sidc="10031000161200000000" />);
     expect(screen.getByTestId('marker')).toBeInTheDocument();
   });
+
+  describe('size precedence', () => {
+    // Compare against a reference render at a known size rather than hardcoding
+    // milsymbol's pixel math, which is not part of this library's contract.
+    const widthFor = (el: React.ReactElement) => {
+      divIconInstances.length = 0;
+      const { unmount } = render(el);
+      const width = (divIconInstances[0].iconSize as number[])[0];
+      unmount();
+      return width;
+    };
+
+    it('lets the size prop win over options.size', () => {
+      expect(
+        widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" size={50} options={{ size: 20 }} />)
+      ).toBe(widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" size={50} />));
+    });
+
+    it('still honours options.size when no size prop is given', () => {
+      expect(
+        widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" options={{ size: 60 }} />)
+      ).toBe(widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" size={60} />));
+    });
+
+    it('defaults to 35 when neither is given', () => {
+      expect(
+        widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" />)
+      ).toBe(widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" size={35} />));
+    });
+
+    it('renders distinct sizes (guards the comparisons above)', () => {
+      const small = widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" size={20} />);
+      const large = widthFor(<MilSymbol position={[0, 0]} sidc="SFG-UCI----D" size={60} />);
+      expect(large).toBeGreaterThan(small);
+    });
+  });
 });

--- a/src/__tests__/iconUpdate.integration.test.tsx
+++ b/src/__tests__/iconUpdate.integration.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MapContainer } from 'react-leaflet';
+import { MilSymbol } from '../components/MilSymbol';
+
+// ponytail: proves the real react-leaflet update path re-renders the icon,
+// so MilSymbol's own setIcon useEffect is redundant.
+const sidcOf = () => screen.getByTestId('map').querySelector('.leaflet-marker-icon svg')?.outerHTML;
+
+describe('icon updates through real react-leaflet', () => {
+    it('swaps the rendered symbol when sidc changes', () => {
+        const { rerender } = render(
+            <div data-testid="map">
+                <MapContainer center={[0, 0]} zoom={3} style={{ height: 400 }}>
+                    <MilSymbol position={[0, 0]} sidc="SFG-UCI----D" />
+                </MapContainer>
+            </div>
+        );
+        const before = sidcOf();
+        expect(before).toBeTruthy();
+
+        rerender(
+            <div data-testid="map">
+                <MapContainer center={[0, 0]} zoom={3} style={{ height: 400 }}>
+                    <MilSymbol position={[0, 0]} sidc="SHG-UCI----D" />
+                </MapContainer>
+            </div>
+        );
+        expect(sidcOf()).not.toBe(before);
+    });
+});

--- a/src/components/MilSymbol.tsx
+++ b/src/components/MilSymbol.tsx
@@ -7,14 +7,17 @@ import { useMilSymbol } from '../hooks/useMilSymbol';
 export const MilSymbol: FC<MilSymbolProps> = ({
     position,
     sidc,
-    size = 35,
+    size,
     options = {},
     tooltipContent,
     popupContent,
     children,
     eventHandlers,
 }) => {
-    const milSymbol = useMilSymbol(sidc, { size, ...options });
+    // The explicit `size` prop wins over `options.size`, but only when actually
+    // supplied — a plain `{ ...options, size }` would let an undefined prop
+    // clobber options.size. The 35 default lives in useMilSymbol.
+    const milSymbol = useMilSymbol(sidc, { ...options, ...(size !== undefined && { size }) });
 
     // ponytail: react-leaflet's updateMarker already calls setIcon when the
     // icon prop identity changes; no manual ref/effect needed.

--- a/src/components/MilSymbol.tsx
+++ b/src/components/MilSymbol.tsx
@@ -1,6 +1,6 @@
-import { FC, useEffect, useMemo, useRef } from 'react';
+import { FC, useMemo } from 'react';
 import { Marker, Tooltip, Popup } from 'react-leaflet';
-import { DivIcon, Marker as LeafletMarker } from 'leaflet';
+import { DivIcon } from 'leaflet';
 import { MilSymbolProps } from '../types';
 import { useMilSymbol } from '../hooks/useMilSymbol';
 
@@ -14,9 +14,10 @@ export const MilSymbol: FC<MilSymbolProps> = ({
     children,
     eventHandlers,
 }) => {
-    const markerRef = useRef<LeafletMarker | null>(null);
     const milSymbol = useMilSymbol(sidc, { size, ...options });
 
+    // ponytail: react-leaflet's updateMarker already calls setIcon when the
+    // icon prop identity changes; no manual ref/effect needed.
     const divIcon = useMemo(() => new DivIcon({
         html: milSymbol.asSVG(),
         className: '',
@@ -24,17 +25,10 @@ export const MilSymbol: FC<MilSymbolProps> = ({
         iconAnchor: [milSymbol.getAnchor().x, milSymbol.getAnchor().y],
     }), [milSymbol]);
 
-    useEffect(() => {
-        if (markerRef.current) {
-            markerRef.current.setIcon(divIcon);
-        }
-    }, [divIcon]);
-
     return (
         <Marker
             position={position}
             icon={divIcon}
-            ref={markerRef}
             eventHandlers={eventHandlers}
         >
             {tooltipContent && (

--- a/src/hooks/useMilSymbol.ts
+++ b/src/hooks/useMilSymbol.ts
@@ -13,7 +13,7 @@ export const useMilSymbol = (sidc: string, options: SymbolOptions = {}) => {
     const optionsKey = JSON.stringify(options);
     return useMemo(() => {
         return new ms.Symbol(sidc, {
-            size: options.size ?? 35,
+            size: 35,
             ...options,
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,83 +1,15 @@
 import { ReactNode } from 'react';
 import { LeafletEventHandlerFnMap } from 'leaflet';
+import { Symbol as MsSymbol } from 'milsymbol';
 
 /**
- * Color mode options for milsymbol
+ * Configuration options for a milsymbol Symbol.
+ *
+ * Derived from milsymbol itself rather than hand-copied, so it tracks
+ * upstream automatically. milsymbol does not export SymbolOptions
+ * directly, but getOptions() returns it.
  */
-export type ColorMode = {
-    Civilian: string;
-    Friend: string;
-    Hostile: string;
-    Neutral: string;
-    Unknown: string;
-    Suspect: string;
-};
-
-/**
- * Direct copy of the SymbolOptions type from milsymbol
- */
-export type SymbolOptions = {
-    additionalInformation?: string;
-    alternateMedal?: boolean;
-    altitudeDepth?: string;
-    auxiliaryEquipmentIndicator?: string;
-    civilianColor?: boolean;
-    colorMode?: ColorMode | string;
-    combatEffectiveness?: string;
-    commonIdentifier?: string;
-    country?: string;
-    direction?: string;
-    dtg?: string;
-    engagementBar?: string;
-    engagementType?: string;
-    equipmentTeardownTime?: string;
-    evaluationRating?: string;
-    fill?: boolean;
-    fillColor?: string;
-    fillOpacity?: number;
-    fontfamily?: string;
-    frame?: boolean;
-    frameColor?: ColorMode;
-    guardedUnit?: string;
-    headquartersElement?: string;
-    higherFormation?: string;
-    hostile?: string;
-    hqStaffLength?: number;
-    icon?: boolean;
-    iconColor?: ColorMode | string;
-    iffSif?: string;
-    infoBackground?: ColorMode | string;
-    infoBackgroundFrame?: ColorMode | string;
-    infoColor?: ColorMode | string;
-    infoFields?: boolean;
-    infoOutlineColor?: string;
-    infoOutlineWidth?: number;
-    infoSize?: number;
-    installationComposition?: string;
-    location?: string;
-    monoColor?: string;
-    outlineColor?: ColorMode | string;
-    outlineWidth?: number;
-    padding?: number;
-    platformType?: string;
-    quantity?: string;
-    reinforcedReduced?: string;
-    sidc?: string;
-    sigint?: string;
-    signatureEquipment?: string;
-    simpleStatusModifier?: boolean;
-    size?: number;
-    specialDesignator?: string;
-    specialHeadquarters?: string;
-    speed?: string;
-    speedLeader?: number;
-    square?: boolean;
-    staffComments?: string;
-    standard?: string;
-    strokeWidth?: number;
-    type?: string;
-    uniqueDesignation?: string;
-};
+export type SymbolOptions = ReturnType<MsSymbol['getOptions']>;
 
 /**
  * Props for the MilSymbol component


### PR DESCRIPTION
Four small fixes to the shipped surface (~180 lines), each verified with a sensitivity control.

## 1. Drop the redundant `setIcon` effect
`MilSymbol.tsx` kept a `markerRef` + `useEffect` calling `setIcon`. It was dead: `react-leaflet/lib/Marker.js` `updateMarker` already calls `marker.setIcon(props.icon)` on icon identity change.

Adds `iconUpdate.integration.test.tsx` — the only test using **real** leaflet/react-leaflet. The existing suite mocks `react-leaflet` wholesale and so cannot catch icon-update regressions.

*Control:* freezing the `divIcon` `useMemo` deps to `[]` makes the new test fail, so it genuinely guards the update path rather than passing vacuously.

## 2. Derive `SymbolOptions` from milsymbol
`types.ts` hand-copied milsymbol's `SymbolOptions` across 108 lines, drifting silently on every upstream release. milsymbol doesn't export the type, but it's reachable via the exported `Symbol` class: `ReturnType<MsSymbol['getOptions']>`.

**108 → 33 lines.** *Control:* compiled a consumer against the emitted `dist/types.d.ts` — a bogus key is still rejected, so the type hasn't collapsed to `any`.

## 3. `size` prop now wins over `options.size` (breaking)
`{ size, ...options }` let the nested value override the explicit prop, which is backwards.

The fix is a conditional spread, not the obvious one. A naive `{ ...options, size }` combined with the existing `size = 35` default would make `size` always defined, so `<MilSymbol options={{ size: 60 }} />` would silently render at **35**. *Control:* that naive version fails the "still honours options.size" test.

| props | before | after |
|---|---|---|
| `size={50} options={{ size: 20 }}` | 20 | **50** |
| `options={{ size: 60 }}` | 60 | 60 |
| neither | 35 | 35 |

## 4. README corrections
The `--legacy-peer-deps` / "react-leaflet only supports React ^18" warning predated react-leaflet v5, which `package.json` already accepts and which supports React 19.

---

**Verification:** lint, `tsc --noEmit`, 36 tests, and build all pass; coverage 100% on both source files.

**Known gap:** item 1 was verified against the installed react-leaflet **5.x** only. Peers allow `^4.0.0`; v4's `updateMarker` contains the same `setIcon` branch by inspection, but was not installed and run.

**Release:** needs a **minor** bump (→ 0.3.0) via the manual `release.yml` dispatch, because of item 3.