### PR TITLE
ci: test against react-leaflet v4 and v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,14 @@ jobs:
           react-leaflet@${{ matrix.react-leaflet }}
           @testing-library/dom@^10
       # A silently-failed override would make the run below meaningless.
+      # Read package.json off disk rather than require()-ing it: react-leaflet's
+      # "exports" map does not expose the ./package.json subpath.
       - name: Verify installed versions
         run: |
           node -e "
-            const rl = require('react-leaflet/package.json').version;
-            const r = require('react/package.json').version;
+            const fs = require('fs');
+            const v = (p) => JSON.parse(fs.readFileSync('node_modules/' + p + '/package.json', 'utf8')).version;
+            const rl = v('react-leaflet'), r = v('react');
             console.log('react-leaflet', rl, '| react', r);
             if (!rl.startsWith('${{ matrix.react-leaflet }}')) throw new Error('react-leaflet override failed: ' + rl);
             if (!r.startsWith('${{ matrix.react }}.')) throw new Error('react override failed: ' + r);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,51 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/coverage-final.json
+
+  # Exercises the peer range in package.json (react-leaflet ^4 || ^5), which the
+  # lockfile alone cannot cover. react-leaflet's own peers pin React per major, so
+  # these axes are paired rather than a cross-product.
+  #
+  # ponytail: pins one version per major, not the whole ^4 || ^5 range.
+  # Add a row when a new major ships.
+  compat:
+    name: react-leaflet ${{ matrix.react-leaflet }} / react ${{ matrix.react }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - react-leaflet: '4.2.1'
+            react: '18'
+          - react-leaflet: '5.0.0'
+            react: '19'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: npm ci
+      # --no-save keeps the lockfile authoritative for the default (v5) build.
+      # --legacy-peer-deps is required because devDependencies still declare React 19,
+      # but it also skips peer installation, which prunes @testing-library/dom
+      # (a peer of @testing-library/react) — so it must be reinstated explicitly.
+      - name: Install compat versions
+        run: npm install --no-save --legacy-peer-deps
+          react@${{ matrix.react }}
+          react-dom@${{ matrix.react }}
+          react-leaflet@${{ matrix.react-leaflet }}
+          @testing-library/dom@^10
+      # A silently-failed override would make the run below meaningless.
+      - name: Verify installed versions
+        run: |
+          node -e "
+            const rl = require('react-leaflet/package.json').version;
+            const r = require('react/package.json').version;
+            console.log('react-leaflet', rl, '| react', r);
+            if (!rl.startsWith('${{ matrix.react-leaflet }}')) throw new Error('react-leaflet override failed: ' + rl);
+            if (!r.startsWith('${{ matrix.react }}.')) throw new Error('react override failed: ' + r);
+          "
+      # Tests only. Lint and typecheck cannot vary by react-leaflet version, a second
+      # Codecov upload would double-report, and the built artifact ships against the
+      # repo's own pinned devDeps — `check` remains the gate for all three.
+      - run: npx vitest run


### PR DESCRIPTION
Closes the known gap carried out of 0.3.0.

## The problem

`package.json` advertises `react-leaflet: ^4.0.0 || ^5.0.0`, but CI only ever installed one point in that range — whatever the lockfile pinned (v5 / React 19).

That mattered concretely: 0.3.0 removed the `setIcon` effect from `MilSymbol.tsx` on the strength of `updateMarker` already calling `marker.setIcon(props.icon)`. That was **executed** against v5 but only **read** for v4. A v4 consumer could have hit "symbols don't update on `sidc` change" with CI fully green.

## Result

**v4 passes — 36/36 against react-leaflet 4.2.1 + React 18.3.1.** The 0.3.0 removal was correct on both majors. That's now an executed result rather than an inspection.

## Design

The axes are **paired, not a cross-product** — react-leaflet pins React per major, so a `[4,5] × [18,19]` matrix would schedule two combos that cannot install:

| react-leaflet | requires |
|---|---|
| `4.2.1` | `react ^18.0.0` |
| `5.0.0` | `react ^19.0.0` |

Deliberate omissions, all justified in comments in the workflow:

- **Tests only** — no lint, no `tsc`, no build, no coverage upload. None of those vary by react-leaflet version, and a second Codecov upload would double-report the same patch. `check` is unchanged and remains the gate for all of them.
- **`fail-fast: false`** so a v4 failure can't cancel v5 and hide whether a break is version-specific.
- **The v5 row is intentionally redundant** with `check`. It makes the matrix self-validating: if the install-override mechanism breaks, v5 fails too, distinguishing "CI plumbing is wrong" from "v4 is broken."

## One trap worth recording

`--legacy-peer-deps` is required (devDeps still declare React 19) but it *also skips peer installation*, which prunes `@testing-library/dom` — a peer of `@testing-library/react@16`. The first v4 run failed with `Cannot find module '@testing-library/dom'`, which looks like a v4 incompatibility and is not one. It's reinstated explicitly in the install step.

The version-verification step **asserts and throws** rather than just printing, so a silently-failed override fails the job instead of producing a meaningless green.

## Verification

- 36/36 under v4.2.1 + React 18.3.1, and under 5.0.0 + React 19.2.8, both run locally with the exact install command the workflow uses.
- **Sensitivity control:** reintroducing the pre-0.3.0 bug (`divIcon` deps → `[]`) makes `iconUpdate.integration.test.tsx` **fail under v4**. Without this, green would only prove the tests ran.
- YAML parsed and asserted: two jobs, correct matrix pairs, `fail-fast: false`.

**Residual gap (deliberate):** pins one version per major, not the full range. Marked with a `ponytail:` comment naming the upgrade path.

No release needed — no shipped code changes.