### PR TITLE
fix: correct docs, add LICENSE and CHANGELOG, warn on invalid SIDCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `useMilSymbol` (and therefore `<MilSymbol />`) now emits a `console.warn` when the
+  supplied SIDC fails milsymbol's `isValid()` check. Previously an invalid SIDC rendered
+  an empty placeholder with no diagnostic, so a typo looked like a missing marker. The
+  warning is deduplicated per SIDC and does not throw — rendering behaviour is unchanged.
+- `LICENSE` file (MIT). The license was already declared in `package.json` but the file
+  itself was missing.
+- This changelog.
+- A "Getting a SIDC" section in the README with copy-paste symbol codes and a link to an
+  interactive SIDC builder.
+
+### Fixed
+
+- README's `useMilSymbol` example called `symbol.toSVG()`, which does not exist. The
+  correct method is `asSVG()`.
+- Package description and assorted documentation described the library as React Leaflet
+  **v4** only. Both v4 and v5 have been supported since 0.3.0 and are covered by CI.
+
+## [0.3.0] - 2026-08-05
+
+### Changed
+
+- **BREAKING**: the `size` prop now takes precedence over `options.size`. If both were
+  passed, the symbol previously rendered at `options.size` and now renders at `size`.
+  Passing only one of them is unaffected.
+
+### Removed
+
+- Dead `useEffect`/`setIcon` block in `MilSymbol`. react-leaflet's own `updateMarker`
+  already calls `setIcon` when the icon prop identity changes.
+
+### Fixed
+
+- `SymbolOptions` is now derived from milsymbol itself rather than hand-copied, so it
+  tracks upstream automatically.
+- Stale README guidance around React 19 and `--legacy-peer-deps`.
+
+## [0.2.3] - 2026-04-03
+
+### Added
+
+- Unified release workflow, CodeQL security analysis, and Codecov coverage reporting.
+
+### Fixed
+
+- npm publish authentication via trusted publishers with OIDC provenance.
+
+## [0.2.0] - 2026-02-12
+
+### Added
+
+- Support for numeric APP-6D SIDCs alongside letter-based APP-6B/C codes.
+- `children` prop on `MilSymbol` for arbitrary react-leaflet children.
+- Test suite, CI workflow, and a GitHub Pages demo app.
+
+### Fixed
+
+- Symbol rendering and memoization.
+
+## [0.1.2] - 2025-03-11
+
+### Added
+
+- Initial release: `MilSymbol` component and `useMilSymbol` hook.
+
+[Unreleased]: https://github.com/jacorbello/react-leaflet-milsymbol/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jacorbello/react-leaflet-milsymbol/compare/v0.2.3...v0.3.0
+[0.2.3]: https://github.com/jacorbello/react-leaflet-milsymbol/compare/v0.2.0...v0.2.3
+[0.2.0]: https://github.com/jacorbello/react-leaflet-milsymbol/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/jacorbello/react-leaflet-milsymbol/releases/tag/v0.1.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 jacorbello
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/jacorbello/react-leaflet-milsymbol/graph/badge.svg?token=I0cmpqpoAm)](https://codecov.io/gh/jacorbello/react-leaflet-milsymbol)
 [![CI](https://github.com/jacorbello/react-leaflet-milsymbol/actions/workflows/ci.yml/badge.svg)](https://github.com/jacorbello/react-leaflet-milsymbol/actions/workflows/ci.yml)
   
-A React Leaflet v4 integration for the milsymbol library, allowing you to easily add military symbols to your React Leaflet maps.
+A React Leaflet integration for the milsymbol library, allowing you to easily add military symbols to your React Leaflet maps. Works with react-leaflet v4 and v5.
 
 **[Live Demo](https://jacorbello.github.io/react-leaflet-milsymbol/)**
 
@@ -34,6 +34,45 @@ This package requires the following peer dependencies:
 - `milsymbol` (v3.0.0 or higher)
 
 Make sure to install these dependencies in your project if you haven't already.
+
+## Getting a SIDC
+
+A **SIDC** (Symbol Identification Code) is the string that tells milsymbol *which* military
+symbol to draw — affiliation (friendly, hostile, …), domain (ground, air, sea), and what the
+unit actually is. It is the only required prop besides `position`, and it is the one thing you
+can't guess.
+
+Two ways to get one:
+
+1. **Build it interactively** — [SIDC Builder (APP-6)](https://sidc.milsymb.net/#/APP6) lets you
+   pick affiliation and unit type from dropdowns and copies out the code.
+2. **Copy one from the table below** and change a single character to adjust it.
+
+> [!TIP]
+> If a symbol renders as an empty box or doesn't appear at all, the SIDC is probably invalid.
+> This library logs a `console.warn` naming the bad code when that happens.
+
+### Common SIDCs
+
+Every code below is verified valid against `milsymbol@3`.
+
+| Symbol | Letter-based (APP-6B/C) | Numeric (APP-6D) |
+| ------ | ----------------------- | ---------------- |
+| Friendly infantry | `SFGPUCI----D` | `10031000141211000000` |
+| Hostile infantry | `SHGPUCI----D` | `10061000141211000000` |
+| Neutral infantry | `SNGPUCI----D` | `10041000141211000000` |
+| Unknown infantry | `SUGPUCI----D` | `10011000141211000000` |
+| Friendly armor | `SFGPUCA----D` | — |
+| Friendly field artillery | `SFGPUCF----D` | — |
+| Friendly air defense | `SFGPUCD----D` | — |
+| Friendly headquarters | `SFGPUH-----D` | — |
+| Friendly fixed-wing aircraft | `SFAPMFF----` | `10030100001101000000` |
+| Friendly rotary-wing aircraft | `SFAPMHR----` | — |
+| Friendly surface combatant | `SFSPCLBB---` | `10033000001201000000` |
+
+**Changing affiliation** in a letter-based code is the 2nd character: `F` friendly (blue),
+`H` hostile (red), `N` neutral (green), `U` unknown (yellow). So `SFGPUCI----D` →
+`SHGPUCI----D` turns friendly infantry into hostile infantry.
 
 ## SIDC Formats
 
@@ -207,7 +246,7 @@ function SymbolPreview() {
   return (
     <div>
       <h3>Symbol Preview</h3>
-      <div dangerouslySetInnerHTML={{ __html: symbol.toSVG() }} />
+      <div dangerouslySetInnerHTML={{ __html: symbol.asSVG() }} />
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-milsymbol",
-  "description": "A React Leaflet v4 wrapper for the milsymbol library",
+  "description": "A React Leaflet (v4 and v5) wrapper for the milsymbol library",
   "private": false,
   "homepage": "https://jacorbello.github.io/react-leaflet-milsymbol/",
   "repository": {
@@ -16,6 +16,7 @@
   "module": "dist/react-leaflet-milsymbol.es.js",
   "types": "dist/index.d.ts",
   "files": [
+    "CHANGELOG.md",
     "dist/*.js",
     "dist/*.js.map",
     "dist/*.d.ts",
@@ -33,6 +34,7 @@
     "leaflet",
     "react-leaflet",
     "react-leaflet-v4",
+    "react-leaflet-v5",
     "milsymbol",
     "military",
     "symbols",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,7 +178,7 @@ const App: FC = () => {
                 <h1>react-leaflet-milsymbol</h1>
                 <p>
                     A React component library for displaying military symbols in Leaflet maps
-                    using the milsymbol library. Easily add military symbols to your React Leaflet v4 maps.
+                    using the milsymbol library. Easily add military symbols to your React Leaflet maps.
                 </p>
             </div>
 

--- a/src/__tests__/useMilSymbol.test.ts
+++ b/src/__tests__/useMilSymbol.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useMilSymbol } from '../hooks/useMilSymbol';
 
@@ -103,5 +103,37 @@ describe('useMilSymbol', () => {
     // JSON.stringify produces different strings for different key orders,
     // so these are different instances (documenting the known limitation)
     expect(first).not.toBe(second);
+  });
+
+  describe('invalid SIDC warning', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    // The dedupe Set in useMilSymbol is module-scoped and persists for the whole
+    // test file, so every SIDC here — valid ones included — must be unique to this
+    // block. Reusing one that an earlier test already passed through would let the
+    // dedupe suppress a warning these tests are supposed to catch.
+
+    it('warns when the SIDC is invalid', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      renderHook(() => useMilSymbol('NOTASIDC-A'));
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('NOTASIDC-A');
+    });
+
+    it('warns only once for the same invalid SIDC', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      renderHook(() => useMilSymbol('NOTASIDC-B'));
+      renderHook(() => useMilSymbol('NOTASIDC-B'));
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not warn for a valid SIDC', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      renderHook(() => useMilSymbol('SFGPEWRH--MT'));
+      renderHook(() => useMilSymbol('10031000001211000000'));
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/hooks/useMilSymbol.ts
+++ b/src/hooks/useMilSymbol.ts
@@ -2,6 +2,10 @@ import { useMemo } from 'react';
 import ms from 'milsymbol';
 import { SymbolOptions } from '../types';
 
+// ponytail: unbounded Set — one entry per distinct bad SIDC, which is bounded in
+// practice. Swap for an LRU if an app ever generates infinite distinct bad codes.
+const warned = new Set<string>();
+
 /**
  * Hook to create and memoize a milsymbol instance
  *
@@ -12,10 +16,24 @@ import { SymbolOptions } from '../types';
 export const useMilSymbol = (sidc: string, options: SymbolOptions = {}) => {
     const optionsKey = JSON.stringify(options);
     return useMemo(() => {
-        return new ms.Symbol(sidc, {
+        const symbol = new ms.Symbol(sidc, {
             size: 35,
             ...options,
         });
+
+        // milsymbol renders an empty placeholder rather than throwing, so without
+        // this a typo'd SIDC is an invisible marker with no diagnostic. Warn rather
+        // than throw to preserve that behaviour; dedupe so re-renders and
+        // StrictMode's double-invoke don't spam the console.
+        if (!symbol.isValid() && !warned.has(sidc)) {
+            warned.add(sidc);
+            console.warn(
+                `[react-leaflet-milsymbol] Invalid SIDC "${sidc}" — the symbol will render ` +
+                `as an empty placeholder. See https://sidc.milsymb.net/#/APP6 to build a valid one.`
+            );
+        }
+
+        return symbol;
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [optionsKey, sidc]);
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
           'react/jsx-runtime': 'jsxRuntime',
         },
         sourcemap: true,
-        banner: '/*\n * react-leaflet-milsymbol\n * A React Leaflet v4 wrapper for milsymbol\n */',
+        banner: '/*\n * react-leaflet-milsymbol\n * A React Leaflet (v4 and v5) wrapper for milsymbol\n */',
       },
     },
     sourcemap: true,


### PR DESCRIPTION
Closes six gaps found in a post-0.3.0 review of the library's consumer-facing surface. The 0.3.0 code itself was in good shape — everything here is about what a user touches: the README, the package metadata, and what happens when they get a SIDC wrong.

## Behavioural change (one)

`useMilSymbol` — and therefore `<MilSymbol />` — now emits a deduplicated `console.warn` when milsymbol's `isValid()` rejects the SIDC:

```
[react-leaflet-milsymbol] Invalid SIDC "NOTASIDC" — the symbol will render as an
empty placeholder. See https://sidc.milsymb.net/#/APP6 to build a valid one.
```

Verified beforehand: `new ms.Symbol('NOTASIDC')` returns `isValid() === false` and renders a meaningless glyph; `new ms.Symbol('')` renders a 2.8×2.8px blob. A typo'd SIDC — the most common beginner mistake — was an invisible marker with no diagnostic.

Design notes:
- **Warns, does not throw.** Rendering a placeholder is milsymbol's own behaviour; escalating would be breaking.
- **Not dev-gated.** `process.env.NODE_ENV` is undefined for raw-ESM/CDN consumers with no bundler, and `import.meta.env.DEV` would bake to `false` at *library* build time, permanently disabling it. A malformed SIDC is worth flagging in production anyway.
- **Deduped by SIDC** via a module-level `Set`, so re-renders and StrictMode's double-invoke don't spam.

Every SIDC already in the tests, demo and README returns `isValid() === true`, so this adds no noise to existing consumers.

## Documentation and packaging

- **`LICENSE`** — declared MIT in `package.json` and referenced by the README, but the file did not exist. Some license scanners fail a dependency on this. Confirmed present in the npm tarball via `npm pack --dry-run`.
- **README `toSVG()` → `asSVG()`** — `toSVG` does not exist on a milsymbol `Symbol`. This was the only documentation of the public hook, so the snippet threw a `TypeError` on copy-paste.
- **New "Getting a SIDC" section** — the biggest gap for a developer without APP-6 background. A link to the interactive builder (already used by the demo at `src/App.tsx:282`, never surfaced in the README) plus an 11-row copy-paste table across the four affiliations, and a note that the 2nd character switches affiliation.
- **Stale "v4"** removed from the package description, README intro, build banner and demo blurb; `react-leaflet-v5` keyword added. The README lines that describe the genuine v4/React-18 constraint are untouched — those are correct.
- **`CHANGELOG.md`** backfilled through 0.1.2, so 0.3.0's breaking `size`-precedence change is recorded outside a README warning block.

## Verification

- Full suite green: **39 tests, 4 files**. Plus `npm run lint`, `npx tsc --noEmit`, `npm run build`.
- **Sensitivity control on the warning.** Removing the `!symbol.isValid()` guard must turn "does not warn for a valid SIDC" red. The first version of that test *did not* fail under sabotage — earlier tests in the file had already pushed those SIDCs into the module-scoped dedupe `Set`, masking the warning. Fixed by giving the block SIDCs unique to it; the control now fails as required and the reasoning is a comment in the test.
- **Sensitivity control on the README fix.** The corrected snippet was transcribed verbatim into a throwaway test and run — passes with `asSVG()`, fails with `TypeError: symbol.toSVG is not a function` under the old text. The defect was precisely that the documented call had never been executed.
- **Every backticked SIDC in the README** (all 19, pre-existing ones included) asserted `isValid() === true` by script, not by eye. Worth doing: an earlier candidate, `10033000001201000000`'s neighbour `10033000001101000000`, came back `false`.
- The affiliation-colour claim in the new README section was checked against emitted SVG fills: F `rgb(128,224,255)`, H `rgb(255,128,128)`, N `rgb(170,255,170)`, U `rgb(255,255,128)`.
- Built artifact inspected: new banner present, warning string present.

## Release

Needs a version bump after merge — the runtime warning and the package description both ship. `patch` → 0.3.1; the warning is additive and nothing else alters behaviour.