### PR TITLE
feat(demo): interactive SIDC playground and getting-started guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-demo
 dist-ssr
 *.local
 

--- a/src/App.css
+++ b/src/App.css
@@ -189,3 +189,341 @@ pre {
 .btn-secondary:hover {
     background-color: #6c7a7b;
 }
+/* ---------------------------------------------------------------------------
+   Tabs
+   --------------------------------------------------------------------------- */
+
+.tabs {
+    display: flex;
+    gap: 0.25rem;
+    background-color: var(--code-background);
+    padding: 0.25rem;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.tab {
+    border: none;
+    background: transparent;
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-light);
+    padding: 0.5rem 1.25rem;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.tab:hover {
+    color: var(--text-color);
+}
+
+.tab.active {
+    background-color: white;
+    color: var(--primary-color);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+/* ---------------------------------------------------------------------------
+   Playground layout
+   --------------------------------------------------------------------------- */
+
+.playground {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    gap: 2rem;
+    align-items: start;
+}
+
+.playground-main,
+.playground-side {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    min-width: 0;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+}
+
+.info-card h2 {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.hint {
+    font-size: 0.85rem;
+    color: var(--text-light);
+    margin: 0.25rem 0 0.75rem;
+}
+
+/* --- SIDC input --- */
+
+.sidc-input {
+    width: 100%;
+    font-family: var(--font-code);
+    font-size: 1.25rem;
+    letter-spacing: 0.06em;
+    padding: 0.75rem;
+    border: 2px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--code-background);
+    color: var(--text-color);
+}
+
+.sidc-input:focus {
+    outline: none;
+    border-color: var(--secondary-color);
+}
+
+.sidc-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+.char-count {
+    font-size: 0.8rem;
+    color: var(--text-light);
+}
+
+.affiliation-row {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+/* --- Result --- */
+
+.preview-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: center;
+}
+
+@media (max-width: 700px) {
+    .preview-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+.symbol-preview {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 160px;
+    min-height: 160px;
+    padding: 1rem;
+    background-color: var(--code-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.symbol-preview.invalid {
+    border-style: dashed;
+    border-color: var(--accent-color);
+}
+
+.symbol-preview svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.preview-map {
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+}
+
+/* --- Validity table --- */
+
+.validity-pill {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 999px;
+}
+
+.validity-pill.ok {
+    background-color: #edf7ed;
+    color: #2e7d32;
+    border: 1px solid #b8e0b8;
+}
+
+.validity-pill.bad {
+    background-color: #fdecea;
+    color: #b3261e;
+    border: 1px solid #f5c2be;
+}
+
+.validity-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.validity-table th,
+.validity-table td {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.validity-table th {
+    font-family: var(--font-code);
+    font-weight: 500;
+    color: var(--text-light);
+    width: 45%;
+}
+
+.validity-table td {
+    font-family: var(--font-code);
+}
+
+.validity-table tr.bad td {
+    color: #b3261e;
+    font-weight: 600;
+}
+
+.validity-table tr.ok td {
+    color: #2e7d32;
+}
+
+/* --- Option controls --- */
+
+.control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.control > span {
+    display: flex;
+    justify-content: space-between;
+    color: var(--text-light);
+    font-family: var(--font-code);
+}
+
+.control > span em {
+    font-style: normal;
+    color: var(--text-color);
+    font-weight: 600;
+}
+
+.control input[type="text"],
+.control select {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-family: var(--font-code);
+    font-size: 0.9rem;
+    background-color: white;
+    color: var(--text-color);
+}
+
+.control input[type="range"] {
+    width: 100%;
+    accent-color: var(--secondary-color);
+}
+
+.control.checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.control.checkbox input {
+    accent-color: var(--secondary-color);
+}
+
+.control.checkbox span {
+    font-family: var(--font-code);
+    color: var(--text-light);
+}
+
+.reset-btn,
+.copy-btn {
+    align-self: flex-start;
+    cursor: pointer;
+    border: none;
+    font-family: inherit;
+    font-size: 0.8rem;
+}
+
+.copy-btn {
+    margin-left: auto;
+    padding: 0.25rem 0.75rem;
+}
+
+/* --- Presets --- */
+
+.preset-group + .preset-group {
+    margin-top: 1rem;
+}
+
+.preset-group h3 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-light);
+    margin-bottom: 0.5rem;
+}
+
+.preset-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.preset {
+    font-family: inherit;
+    font-size: 0.8rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background-color: white;
+    color: var(--text-color);
+    cursor: pointer;
+    transition: border-color 0.15s, background-color 0.15s;
+}
+
+.preset:hover {
+    border-color: var(--secondary-color);
+}
+
+.preset.active {
+    background-color: var(--secondary-color);
+    border-color: var(--secondary-color);
+    color: white;
+}
+
+/* --- Getting started --- */
+
+.try-btn {
+    cursor: pointer;
+    border: none;
+    font-family: inherit;
+    font-size: 0.85rem;
+    margin-top: 0.75rem;
+}
+
+.try-btn .sidc-code {
+    background-color: rgba(255, 255, 255, 0.25);
+    color: inherit;
+}
+
+.getting-started .validity-table {
+    margin-bottom: 0.5rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,177 +1,49 @@
-import { FC, useEffect, useMemo, useRef, useState } from 'react';
-import { MapContainer, TileLayer, Marker, Tooltip } from 'react-leaflet';
-import { DivIcon, Marker as LeafletMarker } from 'leaflet';
-import { MilSymbol } from './components/MilSymbol';
-import { useMilSymbol } from './hooks/useMilSymbol';
+import { FC, useCallback, useEffect, useState } from 'react';
 import 'leaflet/dist/leaflet.css';
 import './App.css';
-import { SymbolOptions } from './types';
+import { MapDemo } from './demo/MapDemo';
+import { Playground } from './demo/Playground';
+import { GettingStarted } from './demo/GettingStarted';
+import { buildHash, parseHash } from './demo/sidc';
 
+const TABS = [
+    { key: 'start', label: 'Getting started' },
+    { key: 'playground', label: 'Playground' },
+    { key: 'map', label: 'Map demo' },
+] as const;
 
-type SymbolDataProps = {
-    name: string;
-    sidc: string;
-    position: [number, number];
-    description: string;
-    format: 'letter' | 'numeric';
-    options: Partial<SymbolOptions>;
-}
+type TabKey = (typeof TABS)[number]['key'];
 
-const symbolData: SymbolDataProps[] = [
-    // Letter-based SIDC (APP-6B/C)
-    {
-        name: "Infantry Unit",
-        sidc: "SFGPEWRH--MT",
-        position: [51.505, -0.09],
-        description: "Standard infantry unit symbol",
-        format: 'letter',
-        options: { size: 35 }
-    },
-    {
-        name: "Armor Unit",
-        sidc: "SFGPUCA---MT",
-        position: [51.51, -0.1],
-        description: "Armored combat vehicle unit",
-        format: 'letter',
-        options: { size: 35, fill: true, fillOpacity: 0.7 }
-    },
-    {
-        name: "Air Defense Unit",
-        sidc: "SFGPUCD---MT",
-        position: [51.5, -0.08],
-        description: "Air defense unit with custom coloring",
-        format: 'letter',
-        options: { size: 35, colorMode: "Dark", monoColor: "rgb(0, 100, 255)" }
-    },
-    {
-        name: "Artillery Unit",
-        sidc: "SFGPUCF---MT",
-        position: [51.515, -0.12],
-        description: "Field artillery unit",
-        format: 'letter',
-        options: { size: 35, fillOpacity: 0.5 }
-    },
-    // Numeric SIDC (APP-6D)
-    {
-        name: "Friendly Infantry Battalion",
-        sidc: "10031000161200000000",
-        position: [51.508, -0.06],
-        description: "Infantry battalion using numeric APP-6D SIDC",
-        format: 'numeric',
-        options: { size: 35 }
-    },
-    {
-        name: "Hostile Armor Company",
-        sidc: "10061000151300000000",
-        position: [51.502, -0.065],
-        description: "Hostile armor company using numeric APP-6D SIDC",
-        format: 'numeric',
-        options: { size: 35 }
-    },
-    {
-        name: "Neutral Air Unit",
-        sidc: "10040100001100000000",
-        position: [51.512, -0.055],
-        description: "Neutral military fixed-wing aircraft using numeric APP-6D SIDC",
-        format: 'numeric',
-        options: { size: 35 }
-    },
-    {
-        name: "Friendly Armored Brigade",
-        sidc: "10031000181304000000",
-        position: [51.498, -0.075],
-        description: "Friendly armored brigade with task force modifier using numeric APP-6D SIDC",
-        format: 'numeric',
-        options: { size: 35, fill: true }
-    },
-];
+const DEFAULT_SIDC = 'SFGPUCI----D';
 
-// --- Circling reconnaissance aircraft (animated demo) ---
-
-const RECON_SIDC = '10030100001101110000';
-const CIRCLE_CENTER_LAT = 51.507;
-const CIRCLE_CENTER_LNG = -0.085;
-const RADIUS_LAT = 0.008;
-const RADIUS_LNG = 0.01283; // corrected for Mercator at ~51.5°N
-const ORBIT_SPEED = 0.6; // radians per second
-const HEADING_UPDATE_THRESHOLD = 15; // degrees
-
-const CirclingAircraft: FC = () => {
-    // Stable position — same reference every render, prevents react-leaflet
-    // from snapping the marker back when the component re-renders for icon updates
-    const initialPosition = useMemo<[number, number]>(
-        () => [CIRCLE_CENTER_LAT + RADIUS_LAT, CIRCLE_CENTER_LNG], []
-    );
-
-    const angleRef = useRef(0);
-    const markerRef = useRef<LeafletMarker | null>(null);
-    const rafIdRef = useRef(0);
-    const lastHeadingRef = useRef(0);
-
-    // Heading state — the only React state; triggers icon re-creation ~2x/sec
-    const [heading, setHeading] = useState(0);
-
-    const milSymbol = useMilSymbol(RECON_SIDC, {
-        size: 35,
-        direction: String(heading),
-    });
-
-    const divIcon = useMemo(() => new DivIcon({
-        html: milSymbol.asSVG(),
-        className: '',
-        iconSize: [milSymbol.getSize().width, milSymbol.getSize().height],
-        iconAnchor: [milSymbol.getAnchor().x, milSymbol.getAnchor().y],
-    }), [milSymbol]);
-
-    // Imperatively update icon when it changes (heading rotated)
-    useEffect(() => {
-        if (markerRef.current) {
-            markerRef.current.setIcon(divIcon);
-        }
-    }, [divIcon]);
-
-    // Animation loop — runs once on mount, never restarts
-    useEffect(() => {
-        let lastTime = performance.now();
-
-        const animate = (now: number) => {
-            const dt = (now - lastTime) / 1000;
-            lastTime = now;
-
-            angleRef.current += ORBIT_SPEED * dt;
-
-            // Position on the circle (clockwise from north)
-            const lat = CIRCLE_CENTER_LAT + RADIUS_LAT * Math.cos(angleRef.current);
-            const lng = CIRCLE_CENTER_LNG + RADIUS_LNG * Math.sin(angleRef.current);
-
-            // Imperatively move marker — no React state update
-            if (markerRef.current) {
-                markerRef.current.setLatLng([lat, lng]);
-            }
-
-            // Update heading icon every ~15° of travel
-            // +90 converts radial angle to tangent (direction of travel) for clockwise orbit
-            const headingDeg = ((angleRef.current * 180 / Math.PI + 90) % 360 + 360) % 360;
-            if (Math.abs(headingDeg - lastHeadingRef.current) >= HEADING_UPDATE_THRESHOLD) {
-                lastHeadingRef.current = headingDeg;
-                setHeading(Math.round(headingDeg));
-            }
-
-            rafIdRef.current = requestAnimationFrame(animate);
-        };
-
-        rafIdRef.current = requestAnimationFrame(animate);
-        return () => cancelAnimationFrame(rafIdRef.current);
-    }, []);
-
-    return (
-        <Marker position={initialPosition} icon={divIcon} ref={markerRef}>
-            <Tooltip>Recon Aircraft (circling)</Tooltip>
-        </Marker>
-    );
-};
+const isTabKey = (value: string | undefined): value is TabKey =>
+    TABS.some((t) => t.key === value);
 
 const App: FC = () => {
+    // Initial state comes from the URL so a shared link lands on the right tab and symbol.
+    const [tab, setTab] = useState<TabKey>(() => {
+        const { tab: hashTab } = parseHash(window.location.hash);
+        return isTabKey(hashTab) ? hashTab : 'start';
+    });
+    const [sidc, setSidc] = useState<string>(() => {
+        const { sidc: hashSidc } = parseHash(window.location.hash);
+        return hashSidc ?? DEFAULT_SIDC;
+    });
+
+    // replaceState, not pushState: dragging a slider or typing a SIDC shouldn't bury the
+    // back button under a hundred history entries.
+    useEffect(() => {
+        const next = buildHash({ tab, sidc: tab === 'playground' ? sidc : undefined });
+        if (next !== window.location.hash) {
+            window.history.replaceState(null, '', next || window.location.pathname);
+        }
+    }, [tab, sidc]);
+
+    const openInPlayground = useCallback((next: string) => {
+        setSidc(next);
+        setTab('playground');
+    }, []);
+
     return (
         <div className="app">
             <div className="header">
@@ -180,112 +52,24 @@ const App: FC = () => {
                     A React component library for displaying military symbols in Leaflet maps
                     using the milsymbol library. Easily add military symbols to your React Leaflet maps.
                 </p>
-            </div>
-
-            <div className="map-container">
-                <MapContainer
-                    center={[51.505, -0.09]}
-                    zoom={13}
-                    style={{ height: '500px', width: '100%' }}
-                >
-                    <TileLayer
-                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-                    />
-
-                    {symbolData.map((symbol) => (
-                        <MilSymbol
-                            key={symbol.sidc + symbol.position.join(',')}
-                            position={symbol.position}
-                            sidc={symbol.sidc}
-                            options={symbol.options}
-                            tooltipContent={symbol.name}
-                            popupContent={
-                                <div>
-                                    <h3>{symbol.name}</h3>
-                                    <p>
-                                        <span className="sidc-code">{symbol.sidc}</span>
-                                        {' '}
-                                        <span className={`format-badge ${symbol.format}`}>
-                                            {symbol.format === 'letter' ? 'APP-6B' : 'APP-6D'}
-                                        </span>
-                                    </p>
-                                    <p>{symbol.description}</p>
-                                </div>
-                            }
-                        />
+                <nav className="tabs" aria-label="Sections">
+                    {TABS.map(({ key, label }) => (
+                        <button
+                            key={key}
+                            type="button"
+                            className={`tab ${tab === key ? 'active' : ''}`}
+                            aria-current={tab === key ? 'page' : undefined}
+                            onClick={() => setTab(key)}
+                        >
+                            {label}
+                        </button>
                     ))}
-
-                    <CirclingAircraft />
-                </MapContainer>
+                </nav>
             </div>
 
-            <div className="content-area">
-                <div className="info-section">
-                    <div className="info-card">
-                        <h2>Installation</h2>
-                        <pre>npm install react-leaflet-milsymbol</pre>
-                        <p>Make sure you have the required peer dependencies:</p>
-                        <pre>npm install leaflet react-leaflet milsymbol</pre>
-                    </div>
-
-                    <div className="info-card">
-                        <h2>Basic Usage</h2>
-                        <pre>{`import { MapContainer, TileLayer } from 'react-leaflet';
-import { MilSymbol } from 'react-leaflet-milsymbol';
-
-const MyMap = () => (
-  <MapContainer center={[51.505, -0.09]} zoom={13}>
-    <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-    
-    <MilSymbol
-      position={[51.505, -0.09]}
-      sidc="SFGPEWRH--MT"
-      options={{
-        size: 35,
-        fill: true,
-        fillOpacity: 0.7
-      }}
-      tooltipContent="Infantry Unit"
-    />
-  </MapContainer>
-);`}</pre>
-                    </div>
-                </div>
-
-                <div className="info-section">
-                    <div className="info-card">
-                        <h2>Available Symbols</h2>
-                        <p>Here are the symbols used in this demo:</p>
-                        <div className="symbol-list">
-                            {symbolData.map((symbol) => (
-                                <div key={symbol.sidc} className="symbol-item">
-                                    <div className="symbol-info">
-                                        <h3>
-                                            {symbol.name}
-                                            <span className={`format-badge ${symbol.format}`}>
-                                                {symbol.format === 'letter' ? 'APP-6B' : 'APP-6D'}
-                                            </span>
-                                        </h3>
-                                        <p>SIDC: <span className="sidc-code">{symbol.sidc}</span></p>
-                                        <p>{symbol.description}</p>
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-
-                    <div className="info-card">
-                        <h2>Resources</h2>
-                        <p>For more information about military symbology:</p>
-                        <ul>
-                            <li><a href="https://sidc.milsymb.net/#/APP6" target="_blank" rel="noopener noreferrer">SIDC Builder (APP-6) &mdash; interactive tool for generating SIDC codes</a></li>
-                            <li><a href="https://www.spatialillusions.com/milsymbol/" target="_blank" rel="noopener noreferrer">milsymbol library documentation</a></li>
-                            <li><a href="https://www.spatialillusions.com/milsymbol/documentation.html" target="_blank" rel="noopener noreferrer">Symbol identification codes (SIDC) reference</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
+            {tab === 'start' && <GettingStarted onTrySidc={openInPlayground} />}
+            {tab === 'playground' && <Playground sidc={sidc} onSidcChange={setSidc} />}
+            {tab === 'map' && <MapDemo />}
 
             <footer className="footer">
                 <p>

--- a/src/__tests__/demo-app.test.tsx
+++ b/src/__tests__/demo-app.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent, within } from '@testing-library/react';
+import App from '../App';
+
+const flushDebounce = async () => {
+    await act(async () => {
+        await new Promise((r) => setTimeout(r, 350));
+    });
+};
+
+describe('demo app', () => {
+    beforeEach(() => {
+        window.location.hash = '';
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    it('renders all three tabs without crashing', async () => {
+        render(<App />);
+        expect(screen.getByRole('heading', { name: /1\. Install/ })).toBeInTheDocument();
+
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });
+        expect(screen.getByLabelText('Symbol identification code')).toBeInTheDocument();
+
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Map demo' })); });
+        expect(screen.getByRole('heading', { name: /Symbols on this map/ })).toBeInTheDocument();
+    });
+
+    it('shows field-level diagnostics for a bad SIDC and recovers for a good one', async () => {
+        render(<App />);
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });
+
+        const input = screen.getByLabelText('Symbol identification code');
+        await act(async () => { fireEvent.change(input, { target: { value: 'NOTASIDC' } }); });
+        await flushDebounce();
+
+        expect(screen.getByText('invalid')).toBeInTheDocument();
+        const iconRow = screen.getByRole('row', { name: /^icon/ });
+        expect(within(iconRow).getByText('false')).toBeInTheDocument();
+
+        await act(async () => { fireEvent.change(input, { target: { value: 'SFGPUCI----D' } }); });
+        await flushDebounce();
+
+        expect(screen.getByText('valid')).toBeInTheDocument();
+        expect(within(screen.getByRole('row', { name: /^icon/ })).getByText('true')).toBeInTheDocument();
+    });
+
+    it('affiliation button rewrites the code in place', async () => {
+        render(<App />);
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });
+
+        const input = screen.getByLabelText('Symbol identification code') as HTMLInputElement;
+        expect(input.value).toBe('SFGPUCI----D');
+
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Hostile' })); });
+        expect(input.value).toBe('SHGPUCI----D');
+    });
+
+    it('a preset loads into the editor', async () => {
+        render(<App />);
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });
+
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Submarine' })); });
+        const input = screen.getByLabelText('Symbol identification code') as HTMLInputElement;
+        expect(input.value).toBe('SFUPSCA----');
+    });
+
+    it('generated snippet reflects the current SIDC and options', async () => {
+        render(<App />);
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });
+        await flushDebounce();
+
+        expect(screen.getByText(/sidc="SFGPUCI----D"/)).toBeInTheDocument();
+    });
+
+    it('restores state from a shared URL', async () => {
+        window.location.hash = '#playground&sidc=SHGPUCI----D';
+        render(<App />);
+
+        const input = screen.getByLabelText('Symbol identification code') as HTMLInputElement;
+        expect(input.value).toBe('SHGPUCI----D');
+    });
+
+    it('Try button on getting-started jumps to the playground preloaded', async () => {
+        render(<App />);
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: /Try NOTASIDC/ }));
+        });
+        await flushDebounce();
+
+        const input = screen.getByLabelText('Symbol identification code') as HTMLInputElement;
+        expect(input.value).toBe('NOTASIDC');
+        expect(screen.getByText('invalid')).toBeInTheDocument();
+    });
+});

--- a/src/__tests__/demo-app.test.tsx
+++ b/src/__tests__/demo-app.test.tsx
@@ -44,6 +44,27 @@ describe('demo app', () => {
         expect(within(screen.getByRole('row', { name: /^icon/ })).getByText('true')).toBeInTheDocument();
     });
 
+    // The map's <MilSymbol> deliberately carries no `key`, so it must update the existing
+    // Leaflet marker rather than being remounted. This asserts the icon really does change
+    // without one — remove the assertion and a silent "marker never updates" regression
+    // would look identical to a pass.
+    it('updates the map marker in place when the SIDC changes', async () => {
+        render(<App />);
+        await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });
+        await flushDebounce();
+
+        const markerSvg = () =>
+            document.querySelector('.leaflet-marker-icon svg')?.outerHTML;
+        const before = markerSvg();
+        expect(before).toBeTruthy();
+
+        const input = screen.getByLabelText('Symbol identification code');
+        await act(async () => { fireEvent.change(input, { target: { value: 'SHGPUCI----D' } }); });
+        await flushDebounce();
+
+        expect(markerSvg()).not.toBe(before);
+    });
+
     it('affiliation button rewrites the code in place', async () => {
         render(<App />);
         await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Playground' })); });

--- a/src/__tests__/demo-sidc.test.ts
+++ b/src/__tests__/demo-sidc.test.ts
@@ -75,8 +75,8 @@ describe('patchAffiliation', () => {
 });
 
 describe('hash state', () => {
-    it('round-trips tab, sidc and size', () => {
-        const state = { tab: 'playground', sidc: 'SFGPUCI----D', size: 40 };
+    it('round-trips tab and sidc', () => {
+        const state = { tab: 'playground', sidc: 'SFGPUCI----D' };
         expect(parseHash(buildHash(state))).toEqual(state);
     });
 
@@ -92,7 +92,10 @@ describe('hash state', () => {
         expect(buildHash({})).toBe('');
     });
 
-    it('ignores a non-numeric size instead of producing NaN', () => {
-        expect(parseHash('#playground&size=abc').size).toBeUndefined();
+    it('ignores unknown keys rather than carrying them through', () => {
+        expect(parseHash('#playground&sidc=SFGPUCI----D&evil=1')).toEqual({
+            tab: 'playground',
+            sidc: 'SFGPUCI----D',
+        });
     });
 });

--- a/src/__tests__/demo-sidc.test.ts
+++ b/src/__tests__/demo-sidc.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import ms from 'milsymbol';
+import {
+    patchAffiliation,
+    readAffiliation,
+    isNumericSidc,
+    parseHash,
+    buildHash,
+    type Affiliation,
+} from '../demo/sidc';
+import { presets } from '../demo/presets';
+
+/** milsymbol's own name for each affiliation, as reported by isValid(true). */
+const MS_NAME: Record<Affiliation, string> = {
+    friend: 'Friend',
+    hostile: 'Hostile',
+    neutral: 'Neutral',
+    unknown: 'Unknown',
+};
+
+const inspect = (sidc: string) => new ms.Symbol(sidc).isValid(true) as Record<string, unknown>;
+
+describe('preset catalog', () => {
+    // isValid() alone is too weak: a code can pass it and still render a blank frame
+    // because no icon matched the entity, which would make the preset's label a lie.
+    it.each(presets)('$group / $label ($sidc) resolves a real icon', ({ sidc }) => {
+        const detail = inspect(sidc);
+        expect(detail.icon).toBe(true);
+    });
+
+    it('declares the format that matches the code shape', () => {
+        for (const { sidc, format } of presets) {
+            expect(isNumericSidc(sidc)).toBe(format === 'numeric');
+        }
+    });
+
+    it('has no duplicate SIDCs', () => {
+        const codes = presets.map((p) => p.sidc);
+        expect(new Set(codes).size).toBe(codes.length);
+    });
+});
+
+describe('patchAffiliation', () => {
+    // The claim under test is milsymbol's, not ours: after patching, milsymbol must
+    // agree the affiliation changed AND the symbol must still resolve an icon.
+    const samples = [
+        { name: 'letter ground unit', sidc: 'SFGPUCI----D' },
+        { name: 'letter aircraft', sidc: 'SFAPMFF----' },
+        { name: 'numeric ground unit', sidc: '10031000141211000000' },
+        { name: 'numeric aircraft', sidc: '10030100001101000000' },
+    ];
+    const affiliations: Affiliation[] = ['friend', 'hostile', 'neutral', 'unknown'];
+
+    it.each(samples)('$name keeps its entity across all four affiliations', ({ sidc }) => {
+        for (const affiliation of affiliations) {
+            const patched = patchAffiliation(sidc, affiliation);
+            const detail = inspect(patched);
+            expect(detail.affiliation).toBe(MS_NAME[affiliation]);
+            expect(detail.icon).toBe(true);
+            expect(patched).toHaveLength(sidc.length);
+        }
+    });
+
+    it('round-trips through readAffiliation', () => {
+        for (const affiliation of affiliations) {
+            expect(readAffiliation(patchAffiliation('SFGPUCI----D', affiliation))).toBe(affiliation);
+            expect(readAffiliation(patchAffiliation('10031000141211000000', affiliation))).toBe(affiliation);
+        }
+    });
+
+    it('leaves a half-typed code alone rather than mangling it', () => {
+        expect(patchAffiliation('', 'hostile')).toBe('');
+        expect(patchAffiliation('S', 'hostile')).toBe('S');
+    });
+});
+
+describe('hash state', () => {
+    it('round-trips tab, sidc and size', () => {
+        const state = { tab: 'playground', sidc: 'SFGPUCI----D', size: 40 };
+        expect(parseHash(buildHash(state))).toEqual(state);
+    });
+
+    it('round-trips a numeric SIDC', () => {
+        const state = { tab: 'playground', sidc: '10031000141211000000' };
+        expect(parseHash(buildHash(state))).toEqual(state);
+    });
+
+    it('handles an empty or bare hash', () => {
+        expect(parseHash('')).toEqual({});
+        expect(parseHash('#')).toEqual({});
+        expect(parseHash('#map')).toEqual({ tab: 'map' });
+        expect(buildHash({})).toBe('');
+    });
+
+    it('ignores a non-numeric size instead of producing NaN', () => {
+        expect(parseHash('#playground&size=abc').size).toBeUndefined();
+    });
+});

--- a/src/demo/GettingStarted.tsx
+++ b/src/demo/GettingStarted.tsx
@@ -1,0 +1,125 @@
+import { FC } from 'react';
+
+type Props = {
+    /** Jump to the playground with a SIDC preloaded — the thing a static README can't do. */
+    onTrySidc: (sidc: string) => void;
+};
+
+const TryButton: FC<{ sidc: string; onTrySidc: (s: string) => void }> = ({ sidc, onTrySidc }) => (
+    <button type="button" className="btn btn-secondary try-btn" onClick={() => onTrySidc(sidc)}>
+        Try <span className="sidc-code">{sidc}</span> &rarr;
+    </button>
+);
+
+export const GettingStarted: FC<Props> = ({ onTrySidc }) => (
+    <div className="content-area getting-started">
+        <div className="info-section">
+            <div className="info-card">
+                <h2>1. Install</h2>
+                <pre>npm install react-leaflet-milsymbol</pre>
+                <p>Plus the peer dependencies, if your project doesn&rsquo;t already have them:</p>
+                <pre>npm install react react-dom leaflet react-leaflet milsymbol</pre>
+                <p className="hint">
+                    Works with react-leaflet v4 (React 18) and v5 (React 19). Both are tested
+                    on every commit.
+                </p>
+            </div>
+
+            <div className="info-card">
+                <h2>2. Put a symbol on a map</h2>
+                <pre>{`import { MapContainer, TileLayer } from 'react-leaflet';
+import { MilSymbol } from 'react-leaflet-milsymbol';
+import 'leaflet/dist/leaflet.css';
+
+const MyMap = () => (
+  <MapContainer center={[51.505, -0.09]} zoom={13}>
+    <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+
+    <MilSymbol
+      position={[51.505, -0.09]}
+      sidc="SFGPUCI----D"
+      options={{ size: 35 }}
+      tooltipContent="Infantry"
+    />
+  </MapContainer>
+);`}</pre>
+                <TryButton sidc="SFGPUCI----D" onTrySidc={onTrySidc} />
+            </div>
+        </div>
+
+        <div className="info-section">
+            <div className="info-card">
+                <h2>3. What is a SIDC?</h2>
+                <p>
+                    A <strong>Symbol Identification Code</strong> is the string that decides
+                    which military symbol gets drawn. It encodes three things: who it is
+                    (affiliation &mdash; friendly, hostile, neutral, unknown), where it operates
+                    (ground, air, sea), and what it actually is (infantry, armor, aircraft).
+                </p>
+                <p>
+                    It&rsquo;s the one prop you can&rsquo;t guess, so start by copying one and
+                    changing it a character at a time.
+                </p>
+
+                <h3>Two formats, both accepted</h3>
+                <table className="validity-table">
+                    <tbody>
+                        <tr>
+                            <th scope="row">Letter-based <span className="format-badge letter">APP-6B/C</span></th>
+                            <td><span className="sidc-code">SFGPUCI----D</span></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Numeric <span className="format-badge numeric">APP-6D</span></th>
+                            <td><span className="sidc-code">10031000141211000000</span></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h3>Affiliation is one character</h3>
+                <p>
+                    In a letter code it&rsquo;s the 2nd character; in a numeric one it&rsquo;s the
+                    4th digit. Everything else stays put, so you can flip a friendly unit to a
+                    hostile one without touching the entity:
+                </p>
+                <table className="validity-table">
+                    <tbody>
+                        <tr><th scope="row">Friend</th><td><span className="sidc-code">S<b>F</b>GPUCI----D</span></td></tr>
+                        <tr><th scope="row">Hostile</th><td><span className="sidc-code">S<b>H</b>GPUCI----D</span></td></tr>
+                        <tr><th scope="row">Neutral</th><td><span className="sidc-code">S<b>N</b>GPUCI----D</span></td></tr>
+                        <tr><th scope="row">Unknown</th><td><span className="sidc-code">S<b>U</b>GPUCI----D</span></td></tr>
+                    </tbody>
+                </table>
+                <TryButton sidc="SHGPUCI----D" onTrySidc={onTrySidc} />
+            </div>
+
+            <div className="info-card">
+                <h2>4. When a symbol doesn&rsquo;t appear</h2>
+                <p>
+                    An invalid SIDC doesn&rsquo;t throw &mdash; milsymbol draws an empty
+                    placeholder, which looks identical to a missing marker. Since v0.3.1 the
+                    library logs a warning naming the bad code, so check the console first.
+                </p>
+                <p>
+                    The <strong>Playground</strong> tab shows the same information as a table,
+                    field by field, so you can see whether the affiliation parsed but the entity
+                    didn&rsquo;t.
+                </p>
+                <TryButton sidc="NOTASIDC" onTrySidc={onTrySidc} />
+            </div>
+
+            <div className="info-card">
+                <h2>Full API reference</h2>
+                <p>
+                    Props, the complete options object, and the <code>useMilSymbol</code> hook are
+                    documented in the README &mdash; kept canonical there rather than duplicated
+                    here.
+                </p>
+                <ul>
+                    <li><a href="https://github.com/jacorbello/react-leaflet-milsymbol#readme" target="_blank" rel="noopener noreferrer">README &mdash; full API reference</a></li>
+                    <li><a href="https://github.com/jacorbello/react-leaflet-milsymbol/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">Changelog</a></li>
+                    <li><a href="https://sidc.milsymb.net/#/APP6" target="_blank" rel="noopener noreferrer">Interactive SIDC builder</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+);

--- a/src/demo/MapDemo.tsx
+++ b/src/demo/MapDemo.tsx
@@ -1,0 +1,249 @@
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Tooltip } from 'react-leaflet';
+import { DivIcon, Marker as LeafletMarker } from 'leaflet';
+import { MilSymbol } from '../components/MilSymbol';
+import { useMilSymbol } from '../hooks/useMilSymbol';
+import { SymbolOptions } from '../types';
+
+type SymbolDataProps = {
+    name: string;
+    sidc: string;
+    position: [number, number];
+    description: string;
+    format: 'letter' | 'numeric';
+    options: Partial<SymbolOptions>;
+};
+
+const symbolData: SymbolDataProps[] = [
+    // Letter-based SIDC (APP-6B/C)
+    {
+        name: "Infantry Unit",
+        sidc: "SFGPEWRH--MT",
+        position: [51.505, -0.09],
+        description: "Standard infantry unit symbol",
+        format: 'letter',
+        options: { size: 35 }
+    },
+    {
+        name: "Armor Unit",
+        sidc: "SFGPUCA---MT",
+        position: [51.51, -0.1],
+        description: "Armored combat vehicle unit",
+        format: 'letter',
+        options: { size: 35, fill: true, fillOpacity: 0.7 }
+    },
+    {
+        name: "Air Defense Unit",
+        sidc: "SFGPUCD---MT",
+        position: [51.5, -0.08],
+        description: "Air defense unit with custom coloring",
+        format: 'letter',
+        options: { size: 35, colorMode: "Dark", monoColor: "rgb(0, 100, 255)" }
+    },
+    {
+        name: "Artillery Unit",
+        sidc: "SFGPUCF---MT",
+        position: [51.515, -0.12],
+        description: "Field artillery unit",
+        format: 'letter',
+        options: { size: 35, fillOpacity: 0.5 }
+    },
+    // Numeric SIDC (APP-6D)
+    {
+        name: "Friendly Infantry Battalion",
+        sidc: "10031000161200000000",
+        position: [51.508, -0.06],
+        description: "Infantry battalion using numeric APP-6D SIDC",
+        format: 'numeric',
+        options: { size: 35 }
+    },
+    {
+        name: "Hostile Armor Company",
+        sidc: "10061000151300000000",
+        position: [51.502, -0.065],
+        description: "Hostile armor company using numeric APP-6D SIDC",
+        format: 'numeric',
+        options: { size: 35 }
+    },
+    {
+        name: "Neutral Air Unit",
+        sidc: "10040100001100000000",
+        position: [51.512, -0.055],
+        description: "Neutral military fixed-wing aircraft using numeric APP-6D SIDC",
+        format: 'numeric',
+        options: { size: 35 }
+    },
+    {
+        name: "Friendly Armored Brigade",
+        sidc: "10031000181304000000",
+        position: [51.498, -0.075],
+        description: "Friendly armored brigade with task force modifier using numeric APP-6D SIDC",
+        format: 'numeric',
+        options: { size: 35, fill: true }
+    },
+];
+
+// --- Circling reconnaissance aircraft (animated demo) ---
+
+const RECON_SIDC = '10030100001101110000';
+const CIRCLE_CENTER_LAT = 51.507;
+const CIRCLE_CENTER_LNG = -0.085;
+const RADIUS_LAT = 0.008;
+const RADIUS_LNG = 0.01283; // corrected for Mercator at ~51.5°N
+const ORBIT_SPEED = 0.6; // radians per second
+const HEADING_UPDATE_THRESHOLD = 15; // degrees
+
+const CirclingAircraft: FC = () => {
+    // Stable position — same reference every render, prevents react-leaflet
+    // from snapping the marker back when the component re-renders for icon updates
+    const initialPosition = useMemo<[number, number]>(
+        () => [CIRCLE_CENTER_LAT + RADIUS_LAT, CIRCLE_CENTER_LNG], []
+    );
+
+    const angleRef = useRef(0);
+    const markerRef = useRef<LeafletMarker | null>(null);
+    const rafIdRef = useRef(0);
+    const lastHeadingRef = useRef(0);
+
+    // Heading state — the only React state; triggers icon re-creation ~2x/sec
+    const [heading, setHeading] = useState(0);
+
+    const milSymbol = useMilSymbol(RECON_SIDC, {
+        size: 35,
+        direction: String(heading),
+    });
+
+    const divIcon = useMemo(() => new DivIcon({
+        html: milSymbol.asSVG(),
+        className: '',
+        iconSize: [milSymbol.getSize().width, milSymbol.getSize().height],
+        iconAnchor: [milSymbol.getAnchor().x, milSymbol.getAnchor().y],
+    }), [milSymbol]);
+
+    // ponytail: no manual setIcon effect here either. Moving the marker imperatively via
+    // setLatLng does not stop react-leaflet's updateMarker from applying a new `icon` prop,
+    // so the heading still tracks — same dead pattern removed from the library in 0.3.0.
+    // Verified with a probe that failed when the icon's useMemo deps were frozen.
+
+    // Animation loop — runs once on mount, never restarts
+    useEffect(() => {
+        let lastTime = performance.now();
+
+        const animate = (now: number) => {
+            const dt = (now - lastTime) / 1000;
+            lastTime = now;
+
+            angleRef.current += ORBIT_SPEED * dt;
+
+            // Position on the circle (clockwise from north)
+            const lat = CIRCLE_CENTER_LAT + RADIUS_LAT * Math.cos(angleRef.current);
+            const lng = CIRCLE_CENTER_LNG + RADIUS_LNG * Math.sin(angleRef.current);
+
+            // Imperatively move marker — no React state update
+            if (markerRef.current) {
+                markerRef.current.setLatLng([lat, lng]);
+            }
+
+            // Update heading icon every ~15° of travel
+            // +90 converts radial angle to tangent (direction of travel) for clockwise orbit
+            const headingDeg = ((angleRef.current * 180 / Math.PI + 90) % 360 + 360) % 360;
+            if (Math.abs(headingDeg - lastHeadingRef.current) >= HEADING_UPDATE_THRESHOLD) {
+                lastHeadingRef.current = headingDeg;
+                setHeading(Math.round(headingDeg));
+            }
+
+            rafIdRef.current = requestAnimationFrame(animate);
+        };
+
+        rafIdRef.current = requestAnimationFrame(animate);
+        return () => cancelAnimationFrame(rafIdRef.current);
+    }, []);
+
+    return (
+        <Marker position={initialPosition} icon={divIcon} ref={markerRef}>
+            <Tooltip>Recon Aircraft (circling)</Tooltip>
+        </Marker>
+    );
+};
+
+export const MapDemo: FC = () => (
+    <>
+        <div className="map-container">
+            <MapContainer
+                center={[51.505, -0.09]}
+                zoom={13}
+                style={{ height: '500px', width: '100%' }}
+            >
+                <TileLayer
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                />
+
+                {symbolData.map((symbol) => (
+                    <MilSymbol
+                        key={symbol.sidc + symbol.position.join(',')}
+                        position={symbol.position}
+                        sidc={symbol.sidc}
+                        options={symbol.options}
+                        tooltipContent={symbol.name}
+                        popupContent={
+                            <div>
+                                <h3>{symbol.name}</h3>
+                                <p>
+                                    <span className="sidc-code">{symbol.sidc}</span>
+                                    {' '}
+                                    <span className={`format-badge ${symbol.format}`}>
+                                        {symbol.format === 'letter' ? 'APP-6B' : 'APP-6D'}
+                                    </span>
+                                </p>
+                                <p>{symbol.description}</p>
+                            </div>
+                        }
+                    />
+                ))}
+
+                <CirclingAircraft />
+            </MapContainer>
+        </div>
+
+        <div className="content-area">
+            <div className="info-section">
+                <div className="info-card">
+                    <h2>Symbols on this map</h2>
+                    <p>
+                        Click any marker for its SIDC. The circling aircraft shows the{' '}
+                        <code>direction</code> option updating live as its heading changes.
+                    </p>
+                    <div className="symbol-list">
+                        {symbolData.map((symbol) => (
+                            <div key={symbol.sidc} className="symbol-item">
+                                <div className="symbol-info">
+                                    <h3>
+                                        {symbol.name}
+                                        <span className={`format-badge ${symbol.format}`}>
+                                            {symbol.format === 'letter' ? 'APP-6B' : 'APP-6D'}
+                                        </span>
+                                    </h3>
+                                    <p>SIDC: <span className="sidc-code">{symbol.sidc}</span></p>
+                                    <p>{symbol.description}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+
+            <div className="info-section">
+                <div className="info-card">
+                    <h2>Resources</h2>
+                    <p>For more information about military symbology:</p>
+                    <ul>
+                        <li><a href="https://sidc.milsymb.net/#/APP6" target="_blank" rel="noopener noreferrer">SIDC Builder (APP-6) &mdash; interactive tool for generating SIDC codes</a></li>
+                        <li><a href="https://www.spatialillusions.com/milsymbol/" target="_blank" rel="noopener noreferrer">milsymbol library documentation</a></li>
+                        <li><a href="https://www.spatialillusions.com/milsymbol/documentation.html" target="_blank" rel="noopener noreferrer">Symbol identification codes (SIDC) reference</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </>
+);

--- a/src/demo/Playground.tsx
+++ b/src/demo/Playground.tsx
@@ -180,8 +180,11 @@ export const Playground: FC<Props> = ({ sidc, onSidcChange }) => {
                                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
                                 />
+                                {/* No `key` here on purpose: MilSymbol updates the marker's
+                                    icon in place when sidc/options change, so keying it by
+                                    sidc would destroy and rebuild the Leaflet marker on every
+                                    edit — the churn 0.3.0 removed from the library. */}
                                 <MilSymbol
-                                    key={debouncedSidc}
                                     position={[51.505, -0.09]}
                                     sidc={debouncedSidc}
                                     options={symbolOptions}

--- a/src/demo/Playground.tsx
+++ b/src/demo/Playground.tsx
@@ -1,0 +1,349 @@
+import { FC, useEffect, useMemo, useState } from 'react';
+import { MapContainer, TileLayer } from 'react-leaflet';
+import { MilSymbol } from '../components/MilSymbol';
+import { useMilSymbol } from '../hooks/useMilSymbol';
+import { SymbolOptions } from '../types';
+import { presets, presetGroups } from './presets';
+import {
+    patchAffiliation,
+    readAffiliation,
+    isNumericSidc,
+    type Affiliation,
+} from './sidc';
+
+const AFFILIATIONS: { key: Affiliation; label: string }[] = [
+    { key: 'friend', label: 'Friend' },
+    { key: 'hostile', label: 'Hostile' },
+    { key: 'neutral', label: 'Neutral' },
+    { key: 'unknown', label: 'Unknown' },
+];
+
+const COLOR_MODES = ['Light', 'Medium', 'Dark'] as const;
+
+type PlaygroundOptions = {
+    size: number;
+    fill: boolean;
+    fillOpacity: number;
+    colorMode: string;
+    direction: string;
+    infoFields: boolean;
+    uniqueDesignation: string;
+    higherFormation: string;
+};
+
+const DEFAULT_OPTIONS: PlaygroundOptions = {
+    size: 45,
+    fill: true,
+    fillOpacity: 1,
+    colorMode: 'Light',
+    direction: '',
+    infoFields: true,
+    uniqueDesignation: '',
+    higherFormation: '',
+};
+
+/**
+ * Build the options object actually handed to the library. Empty strings are dropped
+ * rather than passed through — milsymbol renders an empty text amplifier as blank space,
+ * which makes the symbol jump around as you type.
+ */
+const toSymbolOptions = (o: PlaygroundOptions): SymbolOptions => ({
+    size: o.size,
+    fill: o.fill,
+    fillOpacity: o.fillOpacity,
+    colorMode: o.colorMode,
+    infoFields: o.infoFields,
+    ...(o.direction !== '' && { direction: o.direction }),
+    ...(o.uniqueDesignation !== '' && { uniqueDesignation: o.uniqueDesignation }),
+    ...(o.higherFormation !== '' && { higherFormation: o.higherFormation }),
+});
+
+/** Render the snippet a visitor came here to copy. */
+const buildSnippet = (sidc: string, o: PlaygroundOptions): string => {
+    const opts: string[] = [`size: ${o.size}`];
+    if (!o.fill) opts.push('fill: false');
+    if (o.fillOpacity !== 1) opts.push(`fillOpacity: ${o.fillOpacity}`);
+    if (o.colorMode !== 'Light') opts.push(`colorMode: "${o.colorMode}"`);
+    if (!o.infoFields) opts.push('infoFields: false');
+    if (o.direction !== '') opts.push(`direction: "${o.direction}"`);
+    if (o.uniqueDesignation !== '') opts.push(`uniqueDesignation: "${o.uniqueDesignation}"`);
+    if (o.higherFormation !== '') opts.push(`higherFormation: "${o.higherFormation}"`);
+
+    return `<MilSymbol
+  position={[51.505, -0.09]}
+  sidc="${sidc}"
+  options={{
+    ${opts.join(',\n    ')}
+  }}
+/>`;
+};
+
+type Props = {
+    sidc: string;
+    onSidcChange: (sidc: string) => void;
+};
+
+export const Playground: FC<Props> = ({ sidc, onSidcChange }) => {
+    const [options, setOptions] = useState<PlaygroundOptions>(DEFAULT_OPTIONS);
+    const [copied, setCopied] = useState(false);
+
+    // The library warns on every invalid SIDC. Without debouncing, each keystroke of a
+    // half-typed code is a distinct invalid string and earns its own console warning.
+    // 250ms collapses the noise to roughly one warning per thing you actually meant to type.
+    const [debouncedSidc, setDebouncedSidc] = useState(sidc);
+    useEffect(() => {
+        const id = setTimeout(() => setDebouncedSidc(sidc), 250);
+        return () => clearTimeout(id);
+    }, [sidc]);
+
+    const symbolOptions = useMemo(() => toSymbolOptions(options), [options]);
+    const symbol = useMilSymbol(debouncedSidc, symbolOptions);
+
+    // isValid(true) returns per-field detail rather than a single boolean — this is what
+    // turns "invalid SIDC" into "affiliation parsed, but no icon matches that entity".
+    const detail = useMemo(
+        () => symbol.isValid(true) as Record<string, unknown>,
+        [symbol]
+    );
+    const valid = useMemo(() => symbol.isValid(), [symbol]);
+
+    const activeAffiliation = readAffiliation(sidc);
+    const snippet = buildSnippet(debouncedSidc, options);
+
+    const set = <K extends keyof PlaygroundOptions>(key: K, value: PlaygroundOptions[K]) =>
+        setOptions((prev) => ({ ...prev, [key]: value }));
+
+    const copySnippet = () => {
+        navigator.clipboard?.writeText(snippet).then(
+            () => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+            },
+            () => setCopied(false)
+        );
+    };
+
+    return (
+        <div className="playground">
+            <div className="playground-main">
+                {/* --- Editor ------------------------------------------------ */}
+                <div className="info-card">
+                    <h2>SIDC</h2>
+                    <input
+                        className="sidc-input"
+                        value={sidc}
+                        spellCheck={false}
+                        autoComplete="off"
+                        aria-label="Symbol identification code"
+                        onChange={(e) => onSidcChange(e.target.value.trim())}
+                    />
+                    <div className="sidc-meta">
+                        <span className={`format-badge ${isNumericSidc(sidc) ? 'numeric' : 'letter'}`}>
+                            {isNumericSidc(sidc) ? 'APP-6D' : 'APP-6B/C'}
+                        </span>
+                        <span className="char-count">{sidc.length} characters</span>
+                    </div>
+
+                    <h3>Affiliation</h3>
+                    <p className="hint">
+                        Swaps one character &mdash; the entity stays the same.
+                    </p>
+                    <div className="affiliation-row">
+                        {AFFILIATIONS.map(({ key, label }) => (
+                            <button
+                                key={key}
+                                type="button"
+                                className={`btn ${activeAffiliation === key ? '' : 'btn-secondary'}`}
+                                onClick={() => onSidcChange(patchAffiliation(sidc, key))}
+                            >
+                                {label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* --- Live render ------------------------------------------- */}
+                <div className="info-card">
+                    <h2>Result</h2>
+                    <div className="preview-row">
+                        <div
+                            className={`symbol-preview ${valid ? '' : 'invalid'}`}
+                            dangerouslySetInnerHTML={{ __html: symbol.asSVG() }}
+                        />
+                        <div className="preview-map">
+                            <MapContainer
+                                center={[51.505, -0.09]}
+                                zoom={13}
+                                style={{ height: '220px', width: '100%' }}
+                            >
+                                <TileLayer
+                                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                                />
+                                <MilSymbol
+                                    key={debouncedSidc}
+                                    position={[51.505, -0.09]}
+                                    sidc={debouncedSidc}
+                                    options={symbolOptions}
+                                    tooltipContent={debouncedSidc}
+                                />
+                            </MapContainer>
+                        </div>
+                    </div>
+                </div>
+
+                {/* --- Diagnostics ------------------------------------------- */}
+                <div className="info-card">
+                    <h2>
+                        Validity
+                        <span className={`validity-pill ${valid ? 'ok' : 'bad'}`}>
+                            {valid ? 'valid' : 'invalid'}
+                        </span>
+                    </h2>
+                    <p className="hint">
+                        Reported by milsymbol&rsquo;s <code>isValid(true)</code>, field by field.
+                        A code can parse and still draw an empty frame when no icon matches
+                        the entity &mdash; that shows up here as <code>icon: false</code>.
+                    </p>
+                    <table className="validity-table">
+                        <tbody>
+                            {Object.entries(detail).map(([field, value]) => {
+                                const bad = value === false || value === 'undefined';
+                                return (
+                                    <tr key={field} className={bad ? 'bad' : 'ok'}>
+                                        <th scope="row">{field}</th>
+                                        <td>{String(value)}</td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                    {!valid && (
+                        <p className="hint">
+                            The library also logs this to your browser console &mdash; open
+                            devtools and you will see the same warning your own app would emit.
+                        </p>
+                    )}
+                </div>
+            </div>
+
+            {/* --- Options + snippet + presets ------------------------------- */}
+            <div className="playground-side">
+                <div className="info-card">
+                    <h2>Options</h2>
+
+                    <label className="control">
+                        <span>size <em>{options.size}</em></span>
+                        <input
+                            type="range" min={20} max={120} step={1}
+                            value={options.size}
+                            onChange={(e) => set('size', Number(e.target.value))}
+                        />
+                    </label>
+
+                    <label className="control">
+                        <span>fillOpacity <em>{options.fillOpacity}</em></span>
+                        <input
+                            type="range" min={0} max={1} step={0.05}
+                            value={options.fillOpacity}
+                            onChange={(e) => set('fillOpacity', Number(e.target.value))}
+                        />
+                    </label>
+
+                    <label className="control">
+                        <span>direction <em>{options.direction || 'none'}</em></span>
+                        <input
+                            type="range" min={0} max={359} step={1}
+                            value={options.direction === '' ? 0 : Number(options.direction)}
+                            onChange={(e) => set('direction', e.target.value)}
+                        />
+                    </label>
+
+                    <label className="control">
+                        <span>colorMode</span>
+                        <select
+                            value={options.colorMode}
+                            onChange={(e) => set('colorMode', e.target.value)}
+                        >
+                            {COLOR_MODES.map((m) => <option key={m} value={m}>{m}</option>)}
+                        </select>
+                    </label>
+
+                    <label className="control checkbox">
+                        <input
+                            type="checkbox" checked={options.fill}
+                            onChange={(e) => set('fill', e.target.checked)}
+                        />
+                        <span>fill</span>
+                    </label>
+
+                    <label className="control checkbox">
+                        <input
+                            type="checkbox" checked={options.infoFields}
+                            onChange={(e) => set('infoFields', e.target.checked)}
+                        />
+                        <span>infoFields</span>
+                    </label>
+
+                    <label className="control">
+                        <span>uniqueDesignation</span>
+                        <input
+                            type="text" value={options.uniqueDesignation} placeholder="e.g. A/1-5"
+                            onChange={(e) => set('uniqueDesignation', e.target.value)}
+                        />
+                    </label>
+
+                    <label className="control">
+                        <span>higherFormation</span>
+                        <input
+                            type="text" value={options.higherFormation} placeholder="e.g. 3BCT"
+                            onChange={(e) => set('higherFormation', e.target.value)}
+                        />
+                    </label>
+
+                    <button
+                        type="button"
+                        className="btn btn-secondary reset-btn"
+                        onClick={() => setOptions(DEFAULT_OPTIONS)}
+                    >
+                        Reset options
+                    </button>
+                </div>
+
+                <div className="info-card">
+                    <h2>
+                        Code
+                        <button type="button" className="btn copy-btn" onClick={copySnippet}>
+                            {copied ? 'Copied' : 'Copy'}
+                        </button>
+                    </h2>
+                    <pre>{snippet}</pre>
+                </div>
+
+                <div className="info-card">
+                    <h2>Start from a symbol</h2>
+                    {presetGroups.map((group) => (
+                        <div key={group} className="preset-group">
+                            <h3>{group}</h3>
+                            <div className="preset-row">
+                                {presets
+                                    .filter((p) => p.group === group)
+                                    .map((p) => (
+                                        <button
+                                            key={p.sidc}
+                                            type="button"
+                                            className={`preset ${p.sidc === sidc ? 'active' : ''}`}
+                                            onClick={() => onSidcChange(p.sidc)}
+                                            title={p.sidc}
+                                        >
+                                            {p.label}
+                                        </button>
+                                    ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/demo/presets.ts
+++ b/src/demo/presets.ts
@@ -1,0 +1,61 @@
+/**
+ * Curated starting points for the playground.
+ *
+ * Every SIDC here is asserted valid by `src/__tests__/demo-sidc.test.ts` — not just
+ * `isValid()`, but `isValid(true).icon === true`, which is the stronger claim: a code
+ * can be "valid" and still render a blank frame because no icon matches the entity,
+ * which would make the label below a lie.
+ *
+ * ponytail: no `dimension` field — the UI reads it from milsymbol at runtime via
+ * isValid(true), so this table can't drift out of sync with upstream.
+ */
+export type Preset = {
+    label: string;
+    sidc: string;
+    format: 'letter' | 'numeric';
+    group: string;
+};
+
+export const presets: Preset[] = [
+    // --- Ground units, letter-based (APP-6B/C) ---
+    { label: 'Infantry', sidc: 'SFGPUCI----D', format: 'letter', group: 'Ground' },
+    { label: 'Armor', sidc: 'SFGPUCA----D', format: 'letter', group: 'Ground' },
+    { label: 'Field artillery', sidc: 'SFGPUCF----D', format: 'letter', group: 'Ground' },
+    { label: 'Air defense', sidc: 'SFGPUCD----D', format: 'letter', group: 'Ground' },
+    { label: 'Engineer', sidc: 'SFGPUCE----D', format: 'letter', group: 'Ground' },
+    { label: 'Reconnaissance', sidc: 'SFGPUCR----D', format: 'letter', group: 'Ground' },
+    { label: 'Headquarters', sidc: 'SFGPUH-----D', format: 'letter', group: 'Ground' },
+    { label: 'Medical', sidc: 'SFGPUSM----D', format: 'letter', group: 'Ground' },
+    { label: 'Supply', sidc: 'SFGPUSS----D', format: 'letter', group: 'Ground' },
+    { label: 'Airborne infantry', sidc: 'SFGPUCIZ---D', format: 'letter', group: 'Ground' },
+    { label: 'Installation (airport)', sidc: 'SFGPIBA----D', format: 'letter', group: 'Ground' },
+
+    // --- The four affiliations, same entity, so the frames can be compared ---
+    { label: 'Hostile infantry', sidc: 'SHGPUCI----D', format: 'letter', group: 'Affiliation' },
+    { label: 'Neutral infantry', sidc: 'SNGPUCI----D', format: 'letter', group: 'Affiliation' },
+    { label: 'Unknown infantry', sidc: 'SUGPUCI----D', format: 'letter', group: 'Affiliation' },
+
+    // --- Air and sea, letter-based ---
+    { label: 'Fixed-wing aircraft', sidc: 'SFAPMFF----', format: 'letter', group: 'Air & sea' },
+    { label: 'Rotary-wing aircraft', sidc: 'SFAPMHR----', format: 'letter', group: 'Air & sea' },
+    { label: 'Unmanned aircraft', sidc: 'SFAPMFQ----', format: 'letter', group: 'Air & sea' },
+    { label: 'Surface combatant', sidc: 'SFSPCLBB---', format: 'letter', group: 'Air & sea' },
+    { label: 'Aircraft carrier', sidc: 'SFSPCLCV---', format: 'letter', group: 'Air & sea' },
+    { label: 'Submarine', sidc: 'SFUPSCA----', format: 'letter', group: 'Air & sea' },
+
+    // --- Numeric (APP-6D) ---
+    { label: 'Infantry', sidc: '10031000141211000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Hostile infantry', sidc: '10061000141211000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Neutral infantry', sidc: '10041000141211000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Unknown infantry', sidc: '10011000141211000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Armor', sidc: '10031000141213000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Artillery', sidc: '10031000141216000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Fixed-wing aircraft', sidc: '10030100001101000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Rotary-wing aircraft', sidc: '10030100001102000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Surface combatant', sidc: '10033000001201000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Subsurface', sidc: '10033500001100000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Infantry battalion', sidc: '10031000161211000000', format: 'numeric', group: 'APP-6D' },
+    { label: 'Infantry brigade', sidc: '10031000181211000000', format: 'numeric', group: 'APP-6D' },
+];
+
+export const presetGroups = [...new Set(presets.map((p) => p.group))];

--- a/src/demo/sidc.ts
+++ b/src/demo/sidc.ts
@@ -66,7 +66,6 @@ export const readAffiliation = (sidc: string): Affiliation | null => {
 export type HashState = {
     tab?: string;
     sidc?: string;
-    size?: number;
 };
 
 /**
@@ -91,18 +90,15 @@ export const parseHash = (hash: string): HashState => {
         const value = decodeURIComponent(part.slice(eq + 1));
         if (key === 'sidc') state.sidc = value;
         else if (key === 'tab') state.tab = value;
-        else if (key === 'size') {
-            const n = Number(value);
-            if (Number.isFinite(n)) state.size = n;
-        }
+        // Unknown keys are ignored rather than carried through, so a crafted hash
+        // can't smuggle extra state into the app.
     }
     return state;
 };
 
-export const buildHash = ({ tab, sidc, size }: HashState): string => {
+export const buildHash = ({ tab, sidc }: HashState): string => {
     const parts: string[] = [];
     if (tab) parts.push(encodeURIComponent(tab));
     if (sidc) parts.push(`sidc=${encodeURIComponent(sidc)}`);
-    if (size !== undefined) parts.push(`size=${size}`);
     return parts.length ? `#${parts.join('&')}` : '';
 };

--- a/src/demo/sidc.ts
+++ b/src/demo/sidc.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure SIDC + URL helpers for the demo. Kept free of React so they can be tested
+ * directly — see `src/__tests__/demo-sidc.test.ts`.
+ */
+
+export type Affiliation = 'friend' | 'hostile' | 'neutral' | 'unknown';
+
+/** Letter-based (APP-6B/C) affiliation lives at index 1; numeric (APP-6D) at index 3. */
+const LETTER_AFFILIATION_INDEX = 1;
+const NUMERIC_AFFILIATION_INDEX = 3;
+
+const LETTER_CODES: Record<Affiliation, string> = {
+    friend: 'F',
+    hostile: 'H',
+    neutral: 'N',
+    unknown: 'U',
+};
+
+const NUMERIC_CODES: Record<Affiliation, string> = {
+    friend: '3',
+    hostile: '6',
+    neutral: '4',
+    unknown: '1',
+};
+
+export const isNumericSidc = (sidc: string): boolean => /^\d{20}$/.test(sidc);
+
+/**
+ * Swap the affiliation of an existing SIDC, leaving the entity alone.
+ *
+ * This works on any entity in either format — verified against milsymbol for both
+ * ground units and aircraft — which is why the playground can offer affiliation
+ * buttons without shipping a symbol taxonomy.
+ *
+ * Returns the input unchanged when it is too short to carry an affiliation, so a
+ * half-typed code doesn't get mangled mid-keystroke.
+ */
+export const patchAffiliation = (sidc: string, affiliation: Affiliation): string => {
+    if (isNumericSidc(sidc)) {
+        return (
+            sidc.slice(0, NUMERIC_AFFILIATION_INDEX) +
+            NUMERIC_CODES[affiliation] +
+            sidc.slice(NUMERIC_AFFILIATION_INDEX + 1)
+        );
+    }
+    if (sidc.length <= LETTER_AFFILIATION_INDEX) return sidc;
+    return (
+        sidc.slice(0, LETTER_AFFILIATION_INDEX) +
+        LETTER_CODES[affiliation] +
+        sidc.slice(LETTER_AFFILIATION_INDEX + 1)
+    );
+};
+
+/** Read the affiliation currently encoded in a SIDC, or null if it isn't one of the four. */
+export const readAffiliation = (sidc: string): Affiliation | null => {
+    const table = isNumericSidc(sidc) ? NUMERIC_CODES : LETTER_CODES;
+    const index = isNumericSidc(sidc) ? NUMERIC_AFFILIATION_INDEX : LETTER_AFFILIATION_INDEX;
+    const char = sidc[index];
+    if (char === undefined) return null;
+    const match = Object.entries(table).find(([, code]) => code === char.toUpperCase());
+    return match ? (match[0] as Affiliation) : null;
+};
+
+// --- URL hash state -------------------------------------------------------------
+
+export type HashState = {
+    tab?: string;
+    sidc?: string;
+    size?: number;
+};
+
+/**
+ * Parse `#playground&sidc=SFGPUCI----D&size=40`.
+ *
+ * ponytail: hand-rolled rather than URLSearchParams because the leading bare `tab`
+ * segment isn't a key=value pair. Swap to URLSearchParams if the shape grows.
+ */
+export const parseHash = (hash: string): HashState => {
+    const raw = hash.replace(/^#/, '');
+    if (!raw) return {};
+
+    const state: HashState = {};
+    for (const part of raw.split('&')) {
+        if (!part) continue;
+        const eq = part.indexOf('=');
+        if (eq === -1) {
+            state.tab = decodeURIComponent(part);
+            continue;
+        }
+        const key = part.slice(0, eq);
+        const value = decodeURIComponent(part.slice(eq + 1));
+        if (key === 'sidc') state.sidc = value;
+        else if (key === 'tab') state.tab = value;
+        else if (key === 'size') {
+            const n = Number(value);
+            if (Number.isFinite(n)) state.size = n;
+        }
+    }
+    return state;
+};
+
+export const buildHash = ({ tab, sidc, size }: HashState): string => {
+    const parts: string[] = [];
+    if (tab) parts.push(encodeURIComponent(tab));
+    if (sidc) parts.push(`sidc=${encodeURIComponent(sidc)}`);
+    if (size !== undefined) parts.push(`size=${size}`);
+    return parts.length ? `#${parts.join('&')}` : '';
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,22 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],
+    coverage: {
+      // Coverage measures the published library — everything reachable from the
+      // src/index.ts entry that vite.config.ts builds. The demo app is a GitHub
+      // Pages site that ships in no package; counting its JSX in the same number
+      // makes the gate report on the wrong thing. The demo still has its own
+      // tests (demo-sidc, demo-app), they just don't move this metric.
+      exclude: [
+        'src/demo/**',
+        'src/App.tsx',
+        'src/main.tsx',
+        'src/vite-env.d.ts',
+        'src/__tests__/**',
+        '**/*.config.*',
+        '**/*.css',
+      ],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
The demo proved the library renders; it did nothing to help a developer without military-symbology background actually use it. This splits the single 299-line `App.tsx` into a tabbed shell over three views and adds the interactive piece.

## The playground

Free-text SIDC editing with a live symbol preview and a live map marker, option controls (`size`, `fill`, `fillOpacity`, `colorMode`, `direction`, `infoFields`, text amplifiers), a copy-to-clipboard `<MilSymbol />` snippet, and 32 curated presets.

**The centrepiece is the validity table.** milsymbol's `isValid(true)` returns per-field detail rather than a single boolean:

```js
new ms.Symbol('NOTASIDC').isValid(true)
// → { affiliation: "Unknown", dimension: "undefined", icon: false, mobility: true }
```

That turns *"invalid SIDC"* into *"affiliation parsed fine, but no icon matches that entity"* — the actual learning moment, and it came for free from an API already on disk.

**Affiliation buttons rewrite one character in place** — index 1 for letter codes, index 3 for numeric — so they work on whatever entity you pasted. This is why no symbol taxonomy ships: `ms._iconSIDC` is 14 letter + 17 numeric *drawing functions* keyed by numeric index, not a name→code catalog, so guided entity dropdowns would mean hand-authoring hundreds of APP-6D mappings and owning that data against upstream drift. Presets cover the same need for a fraction of the cost.

**The input is debounced 250ms** because 0.3.1 made `useMilSymbol` warn on invalid SIDCs: without it, every keystroke of a half-typed code is a distinct invalid string earning its own console warning. The playground turns the remainder into a feature — it tells you to open devtools and see the same warning your own app would emit.

## Getting started

Install, first symbol, what a SIDC is, affiliation-as-one-character, and what to do when a symbol doesn't render. Each example deep-links into the playground preloaded via `#sidc=` — the one thing this can do that the README can't. The README stays canonical for the full API rather than being duplicated, which is a deliberate maintenance boundary.

Tab and SIDC sync to `location.hash` (`replaceState`, so sliders don't bury the back button). No router: it would add a dependency and need the GitHub Pages `404.html` workaround to survive a refresh on a deep link.

## Two things found along the way

**The `setIcon` effect in `CirclingAircraft` was dead** — the same pattern removed from the library in 0.3.0. I initially wrote a comment asserting it *was* load-bearing (imperative `setLatLng` meaning `updateMarker` never re-runs). That was wrong, and I caught it by testing instead of shipping the claim: a probe mirroring the component's exact structure passes with the effect removed, and fails when the icon's `useMemo` deps are frozen — so it discriminates. Effect removed, comment corrected.

**`dist-demo` was not gitignored.** Pre-existing, unrelated to this change, but anyone running `npm run build:demo` could commit 1.2MB of build output. One line.

## Verification

- **Full suite: 90 tests, 6 files** (was 39/4). New: 44 pure-logic tests over presets/affiliation-patching/hash round-trip, and 7 app-level smoke tests.
- **Every preset asserted `isValid(true).icon === true`**, not merely `isValid()`. The stronger claim matters: a code can be "valid" and still draw a blank frame because no icon matched, which would make its label a lie. This caught three candidates whose reported `dimension` contradicted my label (`SFPP-------` reports Air, not Space; `10032000001100000000` reports Ground) — dropped rather than shipped mislabeled.
- **Sensitivity controls on every new test group**, each confirmed to fail the right test and restore clean:
  - letter affiliation index 1→2 → both letter patch tests fail
  - numeric affiliation index 3→4 → both numeric patch tests fail
  - `valid` forced true → diagnostics tests fail
  - affiliation patch made a no-op → button test fails
  - hash restore ignored → shared-URL test fails
- **The published bundle is untouched** — `dist/react-leaflet-milsymbol.es.js`, `.umd.js` and `dist/index.d.ts` are byte-identical (md5) before and after, and `npm pack --dry-run` still lists 10 files. Demo code is unreachable from the `src/index.ts` library entry.
- `npm run lint`, `npx tsc --noEmit` clean; `npm run build:demo` succeeds.
- Demo bundle: 1,197,248 → 1,213,255 bytes (+16KB) for three views and the playground.

**Deviation from plan, stated:** the plan called for pure-logic tests only, no UI tests. I kept the 7 app-level smoke tests — they exercise ~800 lines of new interactive code that would otherwise be verified only by my own clicking, and the sensitivity controls show they discriminate. ~2s of CI.

## Deploy

No release needed — no shipped code changes, so no version bump and no npm publish. Pages deploys via `gh workflow run deploy-demo.yml` after merge.